### PR TITLE
[codex] Align frontend with backend auth updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # Backend API URL (for development)
-NEXT_PUBLIC_API_URL=http://localhost:8080/api
+NEXT_PUBLIC_API_URL=http://localhost:8080
 
 # Frontend URL
 NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,11 +20,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -28,8 +33,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/jerky-vault-frontend:latest
-            ${{ secrets.DOCKER_USERNAME }}/jerky-vault-frontend:${{ github.sha }}
+            ghcr.io/dzarlax/jerky-vault-frontend:latest
+            ghcr.io/dzarlax/jerky-vault-frontend:${{ github.sha }}
           file: Dockerfile
           build-args: |
             NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,7 +16,7 @@ The application uses **multi-stage Docker build** with **runtime configuration**
 ### 1. Pull the Image
 
 ```bash
-docker pull dzarlax/jerky-vault-frontend:latest
+docker pull ghcr.io/dzarlax/jerky-vault-frontend:latest
 ```
 
 ### 2. Create docker-compose.yaml
@@ -24,7 +24,7 @@ docker pull dzarlax/jerky-vault-frontend:latest
 ```yaml
 services:
   jerky_vault_frontend:
-    image: dzarlax/jerky-vault-frontend:latest
+    image: ghcr.io/dzarlax/jerky-vault-frontend:latest
     ports:
       - "3000:3000"
     environment:
@@ -59,7 +59,7 @@ The application will be available at `http://localhost:3000`
 
 ## How Runtime Configuration Works
 
-### Build Time (Docker Hub / GitHub Actions)
+### Build Time (GitHub Container Registry / GitHub Actions)
 
 ```dockerfile
 # Multi-stage build
@@ -97,7 +97,7 @@ const mapboxToken = getMapboxToken();
 
 ## Building Locally
 
-If you want to build the image yourself instead of pulling from Docker Hub:
+If you want to build the image yourself instead of pulling from GHCR:
 
 ```bash
 docker build -t jerky-vault-frontend:local .
@@ -183,7 +183,7 @@ Total: ~2 seconds
 The `.github/workflows/main.yml` workflow automatically:
 
 1. Builds image on push to `main` branch
-2. Pushes to Docker Hub with default values
+2. Pushes to GitHub Container Registry with default values
 3. Uses GitHub Actions cache for faster builds
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Create a `.env.local` file in the project root:
 
 ```env
 # API Configuration
-NEXT_PUBLIC_API_URL=http://localhost:8080/api
+NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000
 
 # Authentication

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -16,7 +16,7 @@ services:
         NEXT_DISABLE_SSG: 'true'
         SKIP_ENV_VALIDATION: 'true'
         NODE_ENV: 'production'
-    image: dzarlax/jerky_vault:latest
+    image: ghcr.io/dzarlax/jerky-vault-frontend:latest
     ports:
       - "3000:3000"  # Port for frontend
     environment:

--- a/docs/ai-plans/2026-05-24-frontend-review-fixes.html
+++ b/docs/ai-plans/2026-05-24-frontend-review-fixes.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Implementation Plan: JerkyVault Frontend Review Fixes</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #1f2937;
+      --muted: #5b6472;
+      --border: #d8dde5;
+      --code: #eef1f5;
+      --accent: #8b2635;
+      --warning: #b45309;
+      --danger: #b91c1c;
+      --ok: #047857;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px;
+    }
+    header {
+      margin-bottom: 20px;
+    }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      margin: 16px 0;
+    }
+    h1, h2, h3 {
+      line-height: 1.2;
+      margin-top: 0;
+    }
+    h1 { margin-bottom: 8px; }
+    h2 { font-size: 20px; }
+    p { margin: 8px 0; }
+    ul, ol { margin: 8px 0 0 22px; padding: 0; }
+    li { margin: 6px 0; }
+    code {
+      background: var(--code);
+      padding: 2px 5px;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+      font-size: 0.95em;
+    }
+    .badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: #ead7dc;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0;
+    }
+    .meta {
+      color: var(--muted);
+      margin-top: 6px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 12px;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfd;
+    }
+    .priority {
+      font-weight: 700;
+      color: var(--accent);
+    }
+    .risk { border-left: 4px solid var(--danger); }
+    .approval { border-left: 4px solid var(--warning); }
+    .success { border-left: 4px solid var(--ok); }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Implementation Plan: JerkyVault Frontend Review Fixes</h1>
+    <span class="badge">Approval required before implementation</span>
+    <p class="meta">Created 2026-05-24 for <code>D:\Projects\Code\Personal\jerky-vault</code>. Production code must not be changed until this plan is approved.</p>
+  </header>
+
+  <section>
+    <h2>Task Summary</h2>
+    <p>Fix the concrete frontend issues found during review after backend-side security and API changes: dashboard order action crashes, profile password-change response handling, password validation copy, Windows build script compatibility, and API base URL documentation/config consistency.</p>
+  </section>
+
+  <section>
+    <h2>Current Behavior</h2>
+    <div class="grid">
+      <div class="card">
+        <p><span class="priority">P0</span> Dashboard order actions call <code>mutateDashboardStats()</code>, but the dashboard SWR hook currently exposes the mutate function as <code>mutate</code>. This will throw at runtime after order update, status change, or delete from <code>src/pages/index.tsx</code>.</p>
+      </div>
+      <div class="card">
+        <p><span class="priority">P1</span> <code>src/pages/profile.tsx</code> treats password-change success as <code>response.success</code>, while the backend returns <code>{ "message": "Password changed successfully" }</code>.</p>
+      </div>
+      <div class="card">
+        <p><span class="priority">P2</span> Profile validation uses <code>t('passwordTooShort')</code>, but locale files contain <code>passwordMinLength</code>. The signup page already uses <code>passwordMinLength</code>.</p>
+      </div>
+      <div class="card">
+        <p><span class="priority">P2</span> <code>npm run build:no-ssg</code> fails on Windows because <code>package.json</code> uses POSIX-style inline environment variables.</p>
+      </div>
+      <div class="card">
+        <p><span class="priority">P3</span> <code>.env.example</code> documents <code>NEXT_PUBLIC_API_URL=http://localhost:8080/api</code>, but <code>fetcher</code> appends endpoints such as <code>/api/auth/login</code>. This can produce <code>/api/api/...</code> if copied literally.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Desired Behavior</h2>
+    <ul>
+      <li>Dashboard order update, status change, and delete refresh both the order list and dashboard stats without runtime errors.</li>
+      <li>Profile password change shows success when the backend returns its current successful <code>message</code> response.</li>
+      <li>All frontend password-minimum validation and locale copy consistently use the backend policy of 8 characters.</li>
+      <li>Build commands are runnable from this Windows workspace and remain suitable for Docker/Linux use.</li>
+      <li>API URL examples make it clear whether the variable is the API origin or the full <code>/api</code> base path.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Assumptions and Unknowns</h2>
+    <ul>
+      <li>Backend password policy is intentionally 8 characters, based on inspected <code>../jerky-vault-back/controllers/auth.go</code> and <code>../jerky-vault-back/controllers/profile.go</code>.</li>
+      <li>The frontend should keep using the shared <code>fetcher</code> contract where endpoints include their own <code>/api/...</code> prefix.</li>
+      <li>Deployment is a real VPS-backed service, so build script changes should be conservative and avoid breaking Docker workflows.</li>
+      <li>Existing TypeScript errors outside this fix set are not automatically in scope unless they block the targeted changes or verification.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Files Likely to Change</h2>
+    <ul>
+      <li><code>src/pages/index.tsx</code> - rename the dashboard SWR mutate binding to <code>mutateDashboardStats</code> or update the call sites to the existing <code>mutate</code>.</li>
+      <li><code>src/pages/profile.tsx</code> - accept backend success via <code>response.message</code> or simply treat a resolved fetcher call as success; use the existing <code>passwordMinLength</code> translation key.</li>
+      <li><code>locales/en/common.json</code>, <code>locales/ru/common.json</code>, <code>locales/rs/common.json</code> - only if a clearer dedicated <code>passwordTooShort</code> key is preferred over reusing <code>passwordMinLength</code>.</li>
+      <li><code>package.json</code> - make build scripts cross-platform, likely with <code>cross-env</code> or a small Node script. Adding a dependency should be weighed against keeping scripts shell-specific.</li>
+      <li><code>package-lock.json</code> - if <code>cross-env</code> is added.</li>
+      <li><code>.env.example</code>, <code>README.md</code>, <code>DOCKER.md</code> - align examples with the actual base URL convention.</li>
+      <li><code>docs/ai-plans/2026-05-24-frontend-review-fixes.html</code> - update after implementation with actual changes, checks, limitations, and follow-ups.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Implementation Steps</h2>
+    <ol>
+      <li>Re-check <code>git status --short --branch</code> and preserve the existing local edits as user work.</li>
+      <li>Fix the dashboard mutate binding in <code>src/pages/index.tsx</code>. Preferred small change: destructure <code>mutate: mutateDashboardStats</code> from the dashboard SWR hook.</li>
+      <li>Fix profile password-change success handling so a successful resolved request clears fields and shows the success alert. Keep useful backend error messages in the catch path by reading <code>err.message</code>.</li>
+      <li>Align profile password validation copy with signup by using <code>t('passwordMinLength')</code>, unless a separate locale key is explicitly desired.</li>
+      <li>Decide the cross-platform script approach. Preferred pragmatic option: add <code>cross-env</code> as a dev dependency and update <code>build:docker</code>, <code>build:no-ssg</code>, and <code>start</code>.</li>
+      <li>Normalize API URL examples to the backend origin convention, for example <code>http://localhost:8080</code> and <code>https://api.jerky.in.rs</code>, not values ending in <code>/api</code>.</li>
+      <li>Run targeted verification and update this plan with the final results.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Impact</h2>
+    <ul>
+      <li><strong>API contract:</strong> No backend API changes are planned. The frontend will adapt to the backend's current password-change success response.</li>
+      <li><strong>Auth:</strong> No auth model change. Registration endpoint and 8-character password policy remain aligned with the backend.</li>
+      <li><strong>Deployment:</strong> Build script changes may affect Docker and VPS deploy commands. This is why the plan includes Docker-oriented build verification.</li>
+      <li><strong>UX:</strong> Users should see correct success and validation messages instead of false failure states or raw translation keys.</li>
+      <li><strong>Data/migrations:</strong> No database or migration changes are expected.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Test Plan</h2>
+    <ul>
+      <li><code>npm run lint</code> - should pass.</li>
+      <li><code>npm run build:no-ssg</code> - should run successfully on Windows after script changes.</li>
+      <li><code>npm run build</code> or <code>npm run build:docker</code> - choose based on final script edits; at least one production build path must be verified.</li>
+      <li><code>npx tsc --noEmit</code> - run and record status. Current repo has unrelated type errors, so completion criteria are either "passes" if fixed broadly or "no new relevant errors" if broader type debt remains out of scope.</li>
+      <li>Search check: <code>rg "mutateDashboardStats|passwordTooShort|localhost:8080/api|api/api" src locales README.md DOCKER.md .env.example</code>.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Manual QA Checklist</h2>
+    <ul>
+      <li>Start the frontend locally and sign in with a test account.</li>
+      <li>On dashboard, edit an order and confirm the recent orders/stat cards refresh without console errors.</li>
+      <li>On dashboard, change an order status and confirm the UI refreshes without console errors.</li>
+      <li>On dashboard, delete an order only against test data or a disposable record; confirm the UI refreshes without console errors.</li>
+      <li>On profile, submit a new password shorter than 8 characters and confirm the localized validation message is shown.</li>
+      <li>On profile, change password with valid data and confirm the success alert appears.</li>
+      <li>Confirm the configured API base URL does not generate duplicated <code>/api/api</code> requests in the network tab.</li>
+    </ul>
+  </section>
+
+  <section class="risk">
+    <h2>Risks and Edge Cases</h2>
+    <ul>
+      <li>Adding <code>cross-env</code> modifies dependency metadata. If dependency churn is undesirable, use a small Node wrapper instead.</li>
+      <li>Profile password-change QA can lock a test account into a new password. Use a disposable account or immediately restore the old password.</li>
+      <li>Dashboard delete QA must avoid real production data unless the user explicitly confirms it is safe.</li>
+      <li>Fixing only the reviewed issues leaves existing broader TypeScript debt in place; the plan should clearly report that if <code>tsc</code> still fails.</li>
+      <li>Changing API URL docs must match the actual deploy environment; do not overwrite private <code>.env</code> values unless explicitly requested.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rollback Plan</h2>
+    <p>All expected changes are source/config/documentation edits. Rollback is a normal git revert of the implementation commit or selective restoration of the touched files. If <code>cross-env</code> is added and later rejected, remove it from <code>package.json</code>, regenerate <code>package-lock.json</code>, and restore the prior scripts.</p>
+  </section>
+
+  <section>
+    <h2>Open Questions</h2>
+    <ul>
+      <li>Should the Windows script fix use <code>cross-env</code>, or do you prefer avoiding a new dev dependency?</li>
+      <li>Should this pass also clean the existing broader TypeScript errors, or should it stay tightly scoped to review findings?</li>
+      <li>Should manual QA use local backend/test data only, or is there a known safe staging/prod-like environment for JerkyVault?</li>
+    </ul>
+  </section>
+
+  <section class="approval">
+    <h2>Approval Gate</h2>
+    <p>Approved by the user on 2026-05-24. Implementation was allowed to proceed with emphasis on keeping the GitHub/Docker build path working.</p>
+  </section>
+
+  <section class="success">
+    <h2>Implementation Results</h2>
+    <ul>
+      <li><code>src/pages/index.tsx</code> now aliases the dashboard SWR mutate function as <code>mutateDashboardStats</code> and uses it for retry, manual refresh, order update, status update, and delete refresh paths.</li>
+      <li><code>src/pages/profile.tsx</code> now treats a resolved password-change request as success, clears password fields, and shows the existing success translation. It also uses the existing <code>passwordMinLength</code> key for the 8-character validation message.</li>
+      <li><code>package.json</code> now uses <code>scripts/run-with-env.mjs</code> for cross-platform environment variable setup in <code>build:docker</code>, <code>build:no-ssg</code>, and <code>start</code>. No new npm dependency was added.</li>
+      <li><code>.env.example</code> and <code>README.md</code> now document <code>NEXT_PUBLIC_API_URL</code> as the backend origin, not a value ending in <code>/api</code>.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Checks Run After Implementation</h2>
+    <ul>
+      <li><code>npm run lint</code> passed.</li>
+      <li><code>npm run build</code> passed.</li>
+      <li><code>npm run build:no-ssg</code> passed on Windows through the updated npm script.</li>
+      <li><code>npm run build:docker</code> passed on Windows through the updated npm script.</li>
+      <li><code>npx tsc --noEmit</code> still fails on existing type debt in calculator, charts, modal error handling, SelectDropdown, orders, prices, and products. The dashboard <code>mutate</code>/<code>mutateDashboardStats</code> errors from this fix pass are gone.</li>
+      <li><code>rg "passwordTooShort|localhost:8080/api|api/api|response\?\.success|onClick=\{\(\) =&gt; mutate\(|onRetry=\{\(\) =&gt; mutate\(" src locales README.md DOCKER.md .env.example package.json scripts -n</code> returned no matches.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Known Limitations and Follow-up</h2>
+    <ul>
+      <li>Manual browser QA was not run against a live backend in this pass, to avoid touching real orders or changing a real account password without a disposable test target.</li>
+      <li>Full TypeScript validation remains blocked by pre-existing project-wide type errors. A separate type cleanup pass is recommended before relying on <code>tsc --noEmit</code> as a CI gate.</li>
+      <li>The local build emits a Browserslist stale-data notice. This is not a build failure and was not changed because it would update dependency metadata outside the requested fix scope.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/ai-plans/2026-05-24-ghcr-migration.html
+++ b/docs/ai-plans/2026-05-24-ghcr-migration.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Implementation Plan: Move JerkyVault Images to GitHub Container Registry</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      --bg: #f6f7f9;
+      --panel: #fff;
+      --text: #1f2937;
+      --muted: #5b6472;
+      --border: #d8dde5;
+      --code: #eef1f5;
+      --accent: #8b2635;
+      --warning: #b45309;
+      --danger: #b91c1c;
+      --ok: #047857;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }
+    main { max-width: 1120px; margin: 0 auto; padding: 32px; }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      margin: 16px 0;
+    }
+    h1, h2, h3 { line-height: 1.2; margin-top: 0; }
+    h1 { margin-bottom: 8px; }
+    h2 { font-size: 20px; }
+    p { margin: 8px 0; }
+    ul, ol { margin: 8px 0 0 22px; padding: 0; }
+    li { margin: 6px 0; }
+    code {
+      background: var(--code);
+      padding: 2px 5px;
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+      font-size: 0.95em;
+    }
+    .badge {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: #ead7dc;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+    }
+    .meta { color: var(--muted); margin-top: 6px; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 12px;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfd;
+    }
+    .approval { border-left: 4px solid var(--warning); }
+    .risk { border-left: 4px solid var(--danger); }
+    .success { border-left: 4px solid var(--ok); }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Implementation Plan: Move JerkyVault Images to GitHub Container Registry</h1>
+    <span class="badge">Approved and implemented in frontend PR</span>
+    <p class="meta">Created 2026-05-24 from <code>D:\Projects\Code\Personal\jerky-vault</code>. The approved scope is frontend-only GHCR publishing. Backend migration and live deploy compose changes are handled separately.</p>
+  </header>
+
+  <section>
+    <h2>Task Summary</h2>
+    <p>Migrate the JerkyVault frontend container image from Docker Hub to GitHub Container Registry (GHCR), then update frontend deployment references so the VPS pulls the frontend image from <code>ghcr.io</code>. Backend migration is explicitly out of scope for this plan and will be handled separately.</p>
+  </section>
+
+  <section>
+    <h2>Current Behavior</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Frontend</h3>
+        <p><code>D:\Projects\Code\Personal\jerky-vault\.github\workflows\main.yml</code> logs in to Docker Hub with <code>DOCKER_USERNAME</code> and <code>DOCKER_PASSWORD</code>, then pushes <code>${{ secrets.DOCKER_USERNAME }}/jerky-vault-frontend:latest</code> and a commit-SHA tag.</p>
+      </div>
+      <div class="card">
+        <h3>Backend</h3>
+        <p><code>D:\Projects\Code\Personal\jerky-vault-back\.github\workflows\main.yml</code> still publishes the backend Docker Hub image. This is noted only because the deploy compose contains both services; backend workflow and backend image names are out of scope here.</p>
+      </div>
+      <div class="card">
+        <h3>Deployment</h3>
+        <p><code>D:\Projects\Code\Personal\personal_ai_stack\deploy\jerkyvault\docker-compose.yaml</code> pulls <code>dzarlax/jerky-vault-frontend:latest</code> for the frontend and <code>dzarlax/jerky_vault_backend:latest</code> for the backend. This plan changes only the frontend image line. The deploy file contains live configuration and secrets, so changes must be narrow and reviewable.</p>
+      </div>
+      <div class="card">
+        <h3>Docs</h3>
+        <p>Frontend docs reference <code>dzarlax/jerky-vault-frontend:latest</code>. The example compose file also contains an older frontend image name, <code>dzarlax/jerky_vault:latest</code>, which is already inconsistent with the real deploy state.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Desired Behavior</h2>
+    <ul>
+      <li>Frontend image publishes to <code>ghcr.io/dzarlax/jerky-vault-frontend:latest</code> and <code>ghcr.io/dzarlax/jerky-vault-frontend:${{ github.sha }}</code>.</li>
+      <li>Frontend GitHub Actions use <code>GITHUB_TOKEN</code> and package write permissions instead of Docker Hub secrets.</li>
+      <li>Deployment compose references the GHCR frontend image while leaving the backend Docker Hub image untouched.</li>
+      <li>Frontend documentation and example compose files no longer point frontend deploys at Docker Hub image names.</li>
+      <li>Rollback remains simple: change image references back to Docker Hub and redeploy.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Assumptions and Unknowns</h2>
+    <ul>
+      <li>Target registry is GHCR under the same GitHub owner visible from remotes, <code>dzarlax</code>.</li>
+      <li>The user selected public packages. Public packages avoid requiring <code>docker login ghcr.io</code> on the VPS for pulls.</li>
+      <li>If packages are private, the VPS needs a GHCR read token and a one-time <code>docker login ghcr.io</code>. This should be decided before deploy.</li>
+      <li>The current frontend hotfix PR is separate and should not be mixed with this migration PR.</li>
+      <li>Backend GHCR migration will be performed separately by the user; this plan must not edit backend repository files.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Files Likely to Change</h2>
+    <ul>
+      <li><code>D:\Projects\Code\Personal\jerky-vault\.github\workflows\main.yml</code> - switch login target to <code>ghcr.io</code>, add <code>packages: write</code>, and update image tags.</li>
+      <li><code>D:\Projects\Code\Personal\jerky-vault\DOCKER.md</code> - update pull/compose examples from Docker Hub to GHCR.</li>
+      <li><code>D:\Projects\Code\Personal\jerky-vault\docker-compose.yml.example</code> - update the frontend image example to GHCR and fix the stale frontend image name. Leave the backend example untouched unless it is part of frontend documentation wording.</li>
+      <li><code>D:\Projects\Code\Personal\personal_ai_stack\deploy\jerkyvault\docker-compose.yaml</code> - update only the frontend <code>image:</code> line to the GHCR reference after the frontend package exists; do not edit backend, live secrets, or unrelated deployment settings.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Implementation Steps</h2>
+    <ol>
+      <li>Wait for or intentionally separate from the current frontend hotfix PR, then create a clean branch for GHCR migration.</li>
+      <li>Update frontend workflow to authenticate to GHCR with <code>registry: ghcr.io</code>, <code>username: ${{ github.actor }}</code>, and <code>password: ${{ secrets.GITHUB_TOKEN }}</code>.</li>
+      <li>Add workflow permissions: <code>contents: read</code> and <code>packages: write</code>.</li>
+      <li>Update frontend image tags to <code>ghcr.io/dzarlax/jerky-vault-frontend:latest</code> and commit-SHA tag.</li>
+      <li>Update frontend documentation and compose examples to the GHCR frontend image name.</li>
+      <li>After the GHCR package exists, update <code>personal_ai_stack</code> deploy compose frontend image line only.</li>
+      <li>Open a PR for the frontend repository. If <code>personal_ai_stack</code> changes are committed separately, keep that commit/PR narrowly scoped to the frontend image reference.</li>
+      <li>After merge to <code>main</code>, confirm GitHub Actions publish the frontend package and set package visibility if needed.</li>
+      <li>Deploy by pulling the new GHCR images and restarting the JerkyVault stack, then verify frontend and backend endpoints.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Test Plan</h2>
+    <ul>
+      <li>Frontend: <code>npm run lint</code> and <code>npm run build:docker</code> before opening the PR.</li>
+      <li>Workflow syntax: inspect YAML after edits and, if available, use <code>gh workflow list</code> / GitHub PR checks to verify workflow parsing.</li>
+      <li>Image publishing: after merge, verify frontend package tags exist via GitHub Packages UI or <code>docker manifest inspect ghcr.io/dzarlax/jerky-vault-frontend:latest</code>.</li>
+      <li>Deploy verification: after compose update, run <code>docker compose pull jerky_vault_frontend</code>, <code>docker compose up -d jerky_vault_frontend</code>, check frontend container status/logs, and hit <code>https://admin.jerky.in.rs</code>. Backend endpoint verification is optional sanity checking, not part of the migration.</li>
+    </ul>
+  </section>
+
+  <section class="risk">
+    <h2>Risks and Edge Cases</h2>
+    <ul>
+      <li>GHCR packages may default to private. If so, public VPS pulls will fail until package visibility is changed or the VPS logs in with a token.</li>
+      <li>Docker Hub images should remain available until GHCR deploy is verified, so rollback is immediate.</li>
+      <li>The deploy compose contains live secrets. Edits must be limited to image references and reviewed carefully before commit.</li>
+      <li>Because backend migration is separate, do not change backend image references in this pass.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rollback Plan</h2>
+    <p>If GHCR publish or frontend pulls fail, restore the existing frontend Docker Hub image reference: <code>dzarlax/jerky-vault-frontend:latest</code>. The backend reference remains unchanged by this plan.</p>
+  </section>
+
+  <section>
+    <h2>Open Questions</h2>
+    <ul>
+      <li>GHCR package visibility: answered. Public.</li>
+      <li>Publishing target: answered. GHCR only; no Docker Hub transition window.</li>
+      <li>Deploy compose timing: wait until the frontend GHCR package is visible after merge, then update <code>personal_ai_stack</code>.</li>
+    </ul>
+  </section>
+
+  <section class="approval">
+    <h2>Approval Gate</h2>
+    <p>Approved by the user on 2026-05-24 with public GHCR package visibility and GHCR-only publishing. Backend migration remains out of scope.</p>
+  </section>
+
+  <section class="success">
+    <h2>Implementation Results</h2>
+    <ul>
+      <li><code>.github/workflows/main.yml</code> now logs in to <code>ghcr.io</code> with <code>GITHUB_TOKEN</code>, grants <code>packages: write</code>, and publishes <code>ghcr.io/dzarlax/jerky-vault-frontend:latest</code> plus a commit-SHA tag.</li>
+      <li><code>DOCKER.md</code> now documents the frontend image as a GHCR image instead of a Docker Hub image.</li>
+      <li><code>docker-compose.yml.example</code> now uses <code>ghcr.io/dzarlax/jerky-vault-frontend:latest</code> for the frontend example. The backend image example remains unchanged.</li>
+      <li>Live deploy compose in <code>personal_ai_stack</code> was not changed in this PR. It should be updated after the GHCR package is published and public.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Checks Run After Implementation</h2>
+    <ul>
+      <li><code>npm run lint</code> passed.</li>
+      <li><code>npm run build:docker</code> passed.</li>
+      <li><code>rg "DockerHub|Docker Hub|DOCKER_USERNAME|DOCKER_PASSWORD|dzarlax/jerky-vault-frontend|dzarlax/jerky_vault" .github DOCKER.md docker-compose.yml.example docs\ai-plans\2026-05-24-ghcr-migration.html -n</code> shows no active frontend Docker Hub workflow or docs references; remaining Docker Hub mentions are historical plan context, rollback notes, and backend-out-of-scope references.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -283,7 +283,7 @@
   "enterCurrentPassword": "Enter current password",
   "enterNewPassword": "Enter new password",
   "confirmNewPassword": "Confirm new password",
-  "passwordMinLength": "Minimum 3 characters",
+  "passwordMinLength": "Minimum 8 characters",
   "success": "Success",
   "filterOrders": "Filter Orders",
   "selectProduct": "Select Product",

--- a/locales/rs/common.json
+++ b/locales/rs/common.json
@@ -283,7 +283,7 @@
   "enterCurrentPassword": "Unesite trenutnu lozinku",
   "enterNewPassword": "Unesite novu lozinku",
   "confirmNewPassword": "Potvrdite novu lozinku",
-  "passwordMinLength": "Minimum 3 karaktera",
+  "passwordMinLength": "Minimum 8 karaktera",
   "success": "Uspeh",
   "filterOrders": "Filtriraj narudžbine",
   "selectProduct": "Izaberi proizvod",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -283,7 +283,7 @@
   "enterCurrentPassword": "Введите текущий пароль",
   "enterNewPassword": "Введите новый пароль",
   "confirmNewPassword": "Подтвердите новый пароль",
-  "passwordMinLength": "Минимум 3 символа",
+  "passwordMinLength": "Минимум 8 символов",
   "success": "Успех",
   "filterOrders": "Фильтр заказов",
   "selectProduct": "Выберите продукт",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:docker": "SKIP_ENV_VALIDATION=true NEXT_TELEMETRY_DISABLED=1 NODE_ENV=production next build",
-    "build:no-ssg": "SKIP_ENV_VALIDATION=true NEXT_TELEMETRY_DISABLED=1 NODE_ENV=production NEXT_DISABLE_SSG=true next build",
-    "start": "NODE_ENV=production node server.js",
+    "build:docker": "node scripts/run-with-env.mjs SKIP_ENV_VALIDATION=true NEXT_TELEMETRY_DISABLED=1 NODE_ENV=production -- node node_modules/next/dist/bin/next build",
+    "build:no-ssg": "node scripts/run-with-env.mjs SKIP_ENV_VALIDATION=true NEXT_TELEMETRY_DISABLED=1 NODE_ENV=production NEXT_DISABLE_SSG=true -- node node_modules/next/dist/bin/next build",
+    "start": "node scripts/run-with-env.mjs NODE_ENV=production -- node server.js",
     "start:next": "next start",
     "lint": "next lint",
     "depcheck": "node --loader ts-node/esm ./node_modules/.bin/depcheck"

--- a/scripts/run-with-env.mjs
+++ b/scripts/run-with-env.mjs
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+
+const separatorIndex = process.argv.indexOf('--');
+
+if (separatorIndex === -1 || separatorIndex === process.argv.length - 1) {
+  console.error('Usage: node scripts/run-with-env.mjs KEY=value [KEY=value ...] -- command [args ...]');
+  process.exit(1);
+}
+
+const env = { ...process.env };
+const assignments = process.argv.slice(2, separatorIndex);
+
+for (const assignment of assignments) {
+  const equalsIndex = assignment.indexOf('=');
+
+  if (equalsIndex <= 0) {
+    console.error(`Invalid environment assignment: ${assignment}`);
+    process.exit(1);
+  }
+
+  const key = assignment.slice(0, equalsIndex);
+  const value = assignment.slice(equalsIndex + 1);
+  env[key] = value;
+}
+
+const [command, ...args] = process.argv.slice(separatorIndex + 1);
+const child = spawn(command, args, {
+  env,
+  stdio: 'inherit',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/pages/auth/signup.tsx
+++ b/src/pages/auth/signup.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Form, Button, Container } from 'react-bootstrap';
 import useTranslation from 'next-translate/useTranslation';
+import fetcher from '../../utils/fetcher';
 
 export default function SignUp() {
   const [username, setUsername] = useState('');
@@ -14,15 +15,19 @@ export default function SignUp() {
       alert(t('passwordsDoNotMatch'));
       return;
     }
+    if (password.length < 8) {
+      alert(t('passwordMinLength'));
+      return;
+    }
 
-    const res = await fetch('/api/auth/signup', {
-      method: 'POST',
-      body: JSON.stringify({ username, password }),
-      headers: { 'Content-Type': 'application/json' },
-    });
-    if (res.ok) {
+    try {
+      await fetcher('/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({ username, password }),
+        headers: { 'Content-Type': 'application/json' },
+      });
       alert(t('userRegisteredSuccessfully'));
-    } else {
+    } catch {
       alert(t('failedToRegisterUser'));
     }
   };

--- a/src/pages/clients.tsx
+++ b/src/pages/clients.tsx
@@ -270,7 +270,7 @@ const Clients = ({ mapboxToken }) => {
               </div>
             </div>
           </div>
-        ))}
+        ))
         )}
       </div>
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ const Dashboard = () => {
   const { auth } = useAuth();
   const { success, error: showError } = useNotification();
 
-  const { data: dashboardStats, error: dashboardError, mutate } = useSWR<DashboardStats>(
+  const { data: dashboardStats, error: dashboardError, mutate: mutateDashboardStats } = useSWR<DashboardStats>(
     auth.isAuthenticated ? '/api/dashboard' : null,
     fetcher,
     {
@@ -460,7 +460,7 @@ const Dashboard = () => {
     return (
       <ErrorState 
         message={t('failedToLoadDashboard')} 
-        onRetry={() => mutate()} 
+        onRetry={() => mutateDashboardStats()} 
       />
     );
   }
@@ -482,7 +482,7 @@ const Dashboard = () => {
             Overview of your business metrics
           </p>
         </div>
-        <Button variant="outline-primary" size="sm" onClick={() => mutate()}>
+        <Button variant="outline-primary" size="sm" onClick={() => mutateDashboardStats()}>
           <FaSync className="me-2" />
           {t('refresh')}
         </Button>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -40,16 +40,14 @@ const Profile = () => {
       return;
     }
 
-    // Проверка длины нового пароля
-    if (newPassword.length < 3) {
-      setError(t('passwordTooShort'));
+    if (newPassword.length < 8) {
+      setError(t('passwordMinLength'));
       return;
     }
 
     setIsLoading(true);
     try {
-      // Запрос на изменение пароля
-      const response = await fetcher('/api/profile/change-password', {
+      await fetcher('/api/profile/change-password', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -58,16 +56,12 @@ const Profile = () => {
         body: JSON.stringify({ currentPassword, newPassword }),
       });
 
-      if (response?.success) {
-        setSuccess(t('passwordChangedSuccessfully'));
-        setCurrentPassword('');
-        setNewPassword('');
-        setConfirmPassword('');
-      } else {
-        setError(response?.error || t('unknownError'));
-      }
+      setSuccess(t('passwordChangedSuccessfully'));
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
     } catch (err: any) {
-      setError(err?.error || t('requestFailed'));
+      setError(err?.message || t('requestFailed'));
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- align web signup and password validation with the backend register endpoint and 8-character password policy
- fix dashboard stats refresh callbacks after order actions
- fix profile password-change success handling for the backend message response
- make build scripts cross-platform without adding dependencies
- document API URL examples as backend origins to avoid duplicated /api paths
- move frontend image publishing from Docker Hub to GHCR only
- update frontend Docker docs and compose example to use ghcr.io/dzarlax/jerky-vault-frontend

## Validation
- npm run lint
- npm run build
- npm run build:no-ssg
- npm run build:docker

## Notes
- npx tsc --noEmit still fails on pre-existing project type debt outside this hotfix scope.
- Backend image migration is out of scope and will be handled separately.
- The GHCR package should be made public after the first publish if GitHub creates it as private by default.
- personal_ai_stack deploy compose was not changed in this frontend PR; update its frontend image after the GHCR package exists.