### PR TITLE
[codex] Unify dark theme UI controls

### DIFF
--- a/docs/ai-plans/2026-05-30-dark-theme-modal-consistency.html
+++ b/docs/ai-plans/2026-05-30-dark-theme-modal-consistency.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dark Theme Modal Consistency Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f5f2;
+      --panel: #ffffff;
+      --text: #211b1c;
+      --muted: #6f6265;
+      --border: #ddd4d1;
+      --accent: #8b2635;
+      --accent-soft: #f2e2e5;
+      --risk: #8a4b00;
+      --ok: #116149;
+      --code: #f4eeee;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(1040px, calc(100% - 32px));
+      margin: 32px auto 56px;
+    }
+    header, section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 22px;
+      margin-bottom: 16px;
+      box-shadow: 0 8px 24px rgba(31, 24, 24, 0.05);
+    }
+    h1, h2, h3 { margin: 0 0 10px; line-height: 1.2; }
+    h1 { font-size: 28px; }
+    h2 { font-size: 20px; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+    h3 { font-size: 16px; margin-top: 16px; }
+    p { margin: 0 0 10px; }
+    ul, ol { margin: 8px 0 0 20px; padding: 0; }
+    li { margin: 6px 0; }
+    code {
+      background: var(--code);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+      font-size: 0.92em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 9px 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+    th { background: var(--accent-soft); }
+    .badge {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 2px 8px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-weight: 700;
+      font-size: 12px;
+      margin-right: 6px;
+    }
+    .risk { color: var(--risk); font-weight: 700; }
+    .ok { color: var(--ok); font-weight: 700; }
+    .approval {
+      border-color: var(--accent);
+      background: #fff9fa;
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <span class="badge">Planning gate</span>
+    <span class="badge">Branch: codex/dark-theme-modals-consistency</span>
+    <h1>Dark Theme Modal Consistency</h1>
+    <p>
+      Plan for making all JerkyVault modal dialogs render consistently in dark theme without changing API contracts,
+      data fetching, auth behavior, or production deployment configuration.
+    </p>
+  </header>
+
+  <section>
+    <h2>Task Summary</h2>
+    <p>
+      Audit every modal and normalize dark-theme rendering: modal shells, section surfaces, form controls,
+      select menus, alert blocks, nested item cards, empty states, selected-address panels, and close/action buttons.
+    </p>
+    <p>
+      Adjacent confirmed page-level bug: the ingredients screen search field has a light border in dark theme because
+      its Bootstrap input group addon is not covered by the same tokenized dark styles as modal/form-section controls.
+    </p>
+    <p>
+      The same search-addon border issue is also present on the clients page, so the fix should target shared
+      filter-bar input groups rather than only one page.
+    </p>
+    <p>
+      This is a non-trivial UI task because it touches shared styling and many modal components, so implementation
+      should wait for approval.
+    </p>
+  </section>
+
+  <section>
+    <h2>Current Behavior From Code Inspection</h2>
+    <ul>
+      <li>Global modal styles exist in <code>src/styles/components.css</code>, including dark rules for <code>.modal-content</code>, <code>.modal-header</code>, <code>.modal-footer</code>, alerts, and <code>react-select</code>.</li>
+      <li><code>src/styles/batchvault-adapter.css</code> later overrides <code>.modal-header</code> and <code>.modal-footer</code> back to <code>var(--surface-primary)</code>, which can fight the shared modal dark styling.</li>
+      <li>Several modal bodies contain Bootstrap utility classes such as <code>bg-light</code>, <code>text-dark</code>, and <code>text-muted</code> that are not modal-specific and can look wrong on dark surfaces.</li>
+      <li><code>ClientModal</code> embeds Mapbox Geocoder CSS, which needs explicit dark-theme containment because it is third-party UI inside the modal.</li>
+      <li><code>EditRecipeModal</code> has inline styling for the delete button and a light empty state; both bypass the design token system.</li>
+      <li><code>AddIngredientModal</code> uses light suggestion panels and <code>btn-light</code> suggestion rows inside the dark modal.</li>
+      <li><code>AddPriceModal</code> uses <code>InputGroup.Text</code> for the currency prefix; the existing dark override only targets <code>.form-section .input-group-text</code>, so the <code>₽</code> addon keeps a light Bootstrap background.</li>
+      <li><code>OrderModal</code> and recipe/product modals rely on nested card/section surfaces that should be checked against the modal shell instead of treated as page cards.</li>
+      <li><code>OrderModal</code> footer summary has tokenized surfaces, but <code>.summary-label</code> and <code>.summary-value</code> do not set explicit text colors, making the total price row hard to see or invisible in dark theme.</li>
+      <li>The ingredients and clients page search controls use <code>InputGroup.Text className="bg-transparent"</code> beside tokenized form controls; <code>.input-group-text</code> keeps Bootstrap border behavior outside the scoped product modal <code>.form-section</code> rules.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Desired Behavior</h2>
+    <ul>
+      <li>All modal headers, bodies, footers, and nested panels use existing design-system tokens in both themes.</li>
+      <li>Dark theme has no bright utility backgrounds inside modal content unless they are intentional alert/status colors.</li>
+      <li>Text, helper text, icons, disabled states, invalid feedback, and selected values remain readable in dark theme.</li>
+      <li>React Select menus stay above modals and use consistent dark surfaces whether rendered inline or through the body portal.</li>
+      <li>Mobile modal layout remains stable: footers do not overflow, buttons remain tappable, and long modal bodies scroll within viewport limits.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Likely File Changes</h2>
+    <table>
+      <thead>
+        <tr><th>File</th><th>Likely change</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>src/styles/components.css</code></td>
+          <td>Consolidate shared modal dark-theme rules, close button treatment, form controls, input groups, list groups, alerts, and react-select portal/menu colors.</td>
+        </tr>
+        <tr>
+          <td><code>src/styles/batchvault-adapter.css</code></td>
+          <td>Remove or narrow conflicting modal overrides; add scoped rules for recipe builder, order item cards, ingredient suggestions, and mobile footer behavior where this file already owns those surfaces.</td>
+        </tr>
+        <tr>
+          <td><code>src/components/modal/Clients/ClientModal.tsx</code></td>
+          <td>Replace light/dark Bootstrap utility leakage in selected-address block with semantic classes; keep Mapbox Geocoder behavior unchanged.</td>
+        </tr>
+        <tr>
+          <td><code>src/components/modal/Ingredients/AddIngredientModal.tsx</code></td>
+          <td>Replace light suggestion/type panels and <code>btn-light</code> suggestion rows with modal-specific classes.</td>
+        </tr>
+        <tr>
+          <td><code>src/components/modal/Recipe/EditRecipeModal.tsx</code></td>
+          <td>Replace inline delete button styling and light empty state with tokenized classes.</td>
+        </tr>
+        <tr>
+          <td><code>src/components/modal/Orders/OrderModal.tsx</code>, <code>Products/ProductModal.tsx</code>, <code>Products/PackageModal.tsx</code>, <code>Prices/AddPriceModal.tsx</code></td>
+          <td>Small class adjustments where visual QA confirms inconsistent dark surfaces or controls, including the price modal currency addon and order footer summary text.</td>
+        </tr>
+        <tr>
+          <td><code>src/pages/ingredients.tsx</code>, <code>src/pages/clients.tsx</code>, and shared filter/input CSS</td>
+          <td>Fix the dark-theme search input group border/addon so it matches the rest of the filter bar across list pages.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Implementation Steps</h2>
+    <ol>
+      <li>Create a modal-surface convention using existing tokens: primary shell, secondary nested panel, tertiary header/footer, border, muted text, invalid/alert states.</li>
+      <li>Resolve the global modal header/footer conflict between <code>components.css</code> and <code>batchvault-adapter.css</code> so later rules do not unintentionally flatten dark theme.</li>
+      <li>Replace modal-local Bootstrap light utilities with semantic classes in the components that currently leak light surfaces.</li>
+      <li>Add scoped CSS for third-party and Bootstrap subcomponents inside modals: Mapbox Geocoder, list groups, input groups, disabled controls, close button, and suggestion rows.</li>
+      <li>Apply the same tokenized input-group treatment to filter-bar search fields so the dark-theme border is not light on ingredients or clients pages.</li>
+      <li>Run static verification, then visual QA each modal in the existing compose/dev environment rather than starting a separate local Next.js server.</li>
+      <li>After implementation, update this plan with exact changed files, checks run, known limitations, and follow-up recommendations.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Test Plan</h2>
+    <ul>
+      <li><code>npm run lint</code>.</li>
+      <li><code>npm run build</code>, because prior repo memory says this is the better local verification signal than standalone TypeScript checking for this frontend.</li>
+      <li><code>git diff --check</code>.</li>
+      <li>Manual browser QA in dark theme through the existing dev compose environment: open create/edit flows for clients, ingredients, prices, products/packages, orders/status/delete, and recipes create/edit.</li>
+      <li>Check desktop and mobile widths for footer wrapping, body scrolling, select menus, invalid states, and empty states.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Manual QA Checklist</h2>
+    <ul>
+      <li>Client modal: selected address panel, Mapbox search input/results, validation summary, required-field footer.</li>
+      <li>Ingredient modal: search suggestions, already-added badge, type explanation panel, validation alert.</li>
+      <li>Price modal: ingredient/unit selects, currency input group, error list.</li>
+      <li>Product and package modals: section cards, nested package modal, multi-select chips, delete action.</li>
+      <li>Order modal: item cards, product select menu, read-only price/cost fields, summary footer.</li>
+      <li>Recipe modals: builder side panel, ingredient list, edit modal list group, empty state, delete/clone actions.</li>
+      <li>Status and delete modals: simple modal shell, close buttons, danger/secondary button contrast.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Risks And Rollback</h2>
+    <ul>
+      <li><span class="risk">Risk:</span> changing shared modal CSS can affect every modal at once. Mitigation: keep rules token-based and scope special cases to modal-specific classes.</li>
+      <li><span class="risk">Risk:</span> React Select menus render through <code>document.body</code>, so theme selectors must still apply correctly. Mitigation: verify open menus in dark theme, not just closed controls.</li>
+      <li><span class="risk">Risk:</span> Mapbox Geocoder CSS can override app variables. Mitigation: contain overrides under <code>[data-theme="dark"] .client-modal</code> and avoid behavior changes.</li>
+      <li><span class="ok">Rollback:</span> revert the CSS/component class changes from this branch. No database, API, or deployment migration is planned.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Open Questions</h2>
+    <ul>
+      <li>Should this pass be strictly dark-theme parity, or may it also lightly clean obvious modal UI inconsistencies in light theme when the same CSS rule controls both?</li>
+      <li>For old recipe edit UI, should we only fix dark-theme colors, or is it acceptable to bring it closer to the newer recipe builder styling while staying in the same component?</li>
+    </ul>
+  </section>
+
+  <section class="approval">
+    <h2>Approval Gate</h2>
+    <p>
+      Approved for implementation in this session. The first pass stayed scoped to modal and adjacent list-page
+      dark-theme consistency.
+    </p>
+  </section>
+
+  <section>
+    <h2>Implementation Update</h2>
+    <p>
+      Implemented on <code>2026-05-30</code>. The code changes use shared design tokens rather than one-off colors.
+    </p>
+    <ul>
+      <li><code>src/styles/design-system.css</code>: added shared <code>.input-group-text</code> and dark-theme input-group rules for filter bars and modal bodies.</li>
+      <li><code>src/styles/components.css</code>: added dark close-button treatment, reusable modal token panel/option/empty-state classes, dark list-group styling, client modal Mapbox Geocoder dark styling, and explicit order summary text colors.</li>
+      <li><code>src/components/EmptyState.tsx</code> and <code>src/styles/components.css</code>: replaced Bootstrap <code>Alert variant="light"</code> empty states with a tokenized empty-state shell shared by products, clients, orders, recipes, ingredients, and prices.</li>
+      <li><code>src/styles/batchvault-adapter.css</code>: restored dark modal header/footer background after later adapter overrides.</li>
+      <li><code>src/components/modal/Ingredients/AddIngredientModal.tsx</code>: replaced light suggestion/type panels and <code>btn-light</code> rows with tokenized modal classes.</li>
+      <li><code>src/components/modal/Clients/ClientModal.tsx</code>: replaced the selected-address light panel and <code>text-dark</code> with tokenized modal classes; also moved field icons and required-fields footer copy off Bootstrap text utilities.</li>
+      <li><code>src/components/modal/Recipe/EditRecipeModal.tsx</code>: removed inline delete-button colors and replaced the light empty state with a tokenized empty state.</li>
+      <li><code>src/pages/ingredients.tsx</code> and <code>src/styles/batchvault-adapter.css</code>: stabilized the ingredients filter row so search, type, price state, and clear action do not jump or overflow at narrow desktop widths.</li>
+      <li><code>src/pages/index.tsx</code>, <code>src/pages/orders.tsx</code>, <code>src/components/StatusBadge.tsx</code>, <code>src/components/charts/DonutChart.tsx</code>, and <code>src/styles/batchvault-adapter.css</code>: replaced bright dashboard status pills and chart colors with shared status badges, muted chart tokens, and distinct low-saturation status variants in dark theme.</li>
+      <li><code>src/utils/ingredientTypes.ts</code> and <code>src/components/IngredientTypeBadge.tsx</code>: centralized ingredient type metadata, badge rendering, icons, and unit mappings so ingredients, prices, and recipe/price modals no longer define type display separately.</li>
+      <li><code>src/components/filters/FilterBar.tsx</code>: added shared filter primitives for filter bars, labeled fields, search inputs, chip groups, and clear buttons.</li>
+      <li><code>src/pages/clients.tsx</code>, <code>src/pages/ingredients.tsx</code>, <code>src/pages/orders.tsx</code>, <code>src/pages/prices.tsx</code>, <code>src/pages/products.tsx</code>, and <code>src/pages/recipes.tsx</code>: moved list-page filters onto the shared primitives while keeping page-specific filtering logic local.</li>
+      <li><code>src/pages/profile.tsx</code> and <code>src/styles/components.css</code>: cleaned up the profile page cards, info rows, status badge, password fields, and password visibility buttons so the profile form follows the same tokenized control treatment in dark theme.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Checks Run</h2>
+    <ul>
+      <li><code>npm run lint</code>: passed with no ESLint warnings or errors; Next.js still reports the existing plugin-detection warning.</li>
+      <li><code>npm run build</code>: passed and compiled the Next.js production build successfully.</li>
+      <li><code>git diff --check</code>: passed; Git reported line-ending normalization warnings only.</li>
+      <li><code>docker compose -f docker-compose.dev.yml ps</code>: confirmed the existing dev compose frontend and backend were already running.</li>
+      <li>Browser computed-style smoke on <code>http://localhost:3000/auth/signin</code> with <code>data-theme="dark"</code>: confirmed filter search addon, modal currency addon, modal inputs, order summary text, modal token panel, and modal token option resolve to dark token colors and borders.</li>
+      <li>Authenticated browser QA with test login <code>123 / 123</code>: products page package <code>Тест</code> with zero products, clients no-match search, ingredients no-match search, recipes no-match search, and prices date filter all showed tokenized dark empty states.</li>
+      <li>Authenticated browser QA on client modal: confirmed field icons, input addon surfaces, and required-fields footer note resolve to dark token colors.</li>
+      <li>Browser computed-style smoke on the authenticated dashboard in dark theme: confirmed recent-order status pills use muted text/surface/border colors, <code>Новый заказ</code> and <code>Готово</code> resolve to distinct variants, Bootstrap status badges are no longer present in the table, and donut arcs resolve to the muted chart token palette.</li>
+      <li>Browser computed-style smoke on ingredients and prices in dark theme: confirmed both tables render shared <code>.ingredient-type-badge</code> variants and old table-local <code>badge-primary</code>/<code>badge-warning</code>/<code>badge-info</code>/<code>badge-secondary</code> classes are no longer present.</li>
+      <li>Browser layout smoke on clients, ingredients, orders, prices, products, and recipes: confirmed shared filter controls use aligned labels and 40px control height; the recipe search input-group renders as one connected control; ingredients filter does not overflow at 1024px wide.</li>
+      <li>Browser computed-style smoke on profile password controls: confirmed all three password groups use 40px controls, 40x40 visibility buttons, connected dark borders, and no horizontal overflow on a narrow viewport.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Known Limitations</h2>
+    <ul>
+      <li>Authenticated end-to-end modal clicking was limited to non-mutating flows. It did not create, edit, or delete real clients, ingredients, prices, products, orders, or recipes.</li>
+      <li>Orders empty state could not be naturally triggered in the current dev data because the workspace has existing orders; the shared <code>EmptyState</code> component now covers that route when it becomes empty.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Button } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import {
   FaBoxOpen,
   FaUsers,
@@ -29,21 +29,21 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   const getDefaultIcon = () => {
     switch (type) {
       case 'products':
-        return <FaBoxOpen size={64} className="text-muted mb-3" />;
+        return <FaBoxOpen size={64} />;
       case 'clients':
-        return <FaUsers size={64} className="text-muted mb-3" />;
+        return <FaUsers size={64} />;
       case 'orders':
-        return <FaShoppingCart size={64} className="text-muted mb-3" />;
+        return <FaShoppingCart size={64} />;
       case 'recipes':
-        return <FaUtensils size={64} className="text-muted mb-3" />;
+        return <FaUtensils size={64} />;
       case 'ingredients':
-        return <FaClipboardList size={64} className="text-muted mb-3" />;
+        return <FaClipboardList size={64} />;
       case 'prices':
-        return <FaDollarSign size={64} className="text-muted mb-3" />;
+        return <FaDollarSign size={64} />;
       case 'packages':
-        return <FaTags size={64} className="text-muted mb-3" />;
+        return <FaTags size={64} />;
       default:
-        return <FaExclamationTriangle size={64} className="text-muted mb-3" />;
+        return <FaExclamationTriangle size={64} />;
     }
   };
 
@@ -72,17 +72,19 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   const displayMessage = message || getDefaultMessage();
 
   return (
-    <Alert variant="light" className="text-center py-5">
-      <div className="d-flex flex-column align-items-center">
+    <div className={`empty-state empty-state-${type}`} role="status">
+      <div className="empty-state-content">
+        <div className="empty-state-icon">
         {displayIcon}
-        <h5 className="text-muted mb-3">{displayMessage}</h5>
+        </div>
+        <h5 className="empty-state-title">{displayMessage}</h5>
         {actionLabel && onAction && (
-          <Button variant="primary" onClick={onAction} className="mt-2">
+          <Button variant="primary" onClick={onAction} className="empty-state-action">
             {actionLabel}
           </Button>
         )}
       </div>
-    </Alert>
+    </div>
   );
 };
 

--- a/src/components/IngredientTypeBadge.tsx
+++ b/src/components/IngredientTypeBadge.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { getIngredientTypeBadgeClass, getIngredientTypeMeta } from '../utils/ingredientTypes';
+
+type IngredientTypeBadgeProps = {
+  type?: string;
+  label: string;
+};
+
+const IngredientTypeBadge: React.FC<IngredientTypeBadgeProps> = ({ type, label }) => {
+  const meta = getIngredientTypeMeta(type);
+  const IconComponent = meta.icon;
+
+  return (
+    <span className={`ingredient-type-badge ${getIngredientTypeBadgeClass(type)}`}>
+      <IconComponent className="me-1" />
+      {label}
+    </span>
+  );
+};
+
+export default IngredientTypeBadge;

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -2,15 +2,32 @@ import React from 'react';
 
 interface StatusBadgeProps {
   status: string;
-  variant?: 'success' | 'warning' | 'error' | 'info';
+  variant?: 'brand' | 'success' | 'warning' | 'error' | 'info';
 }
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   status,
   variant = 'info',
 }) => {
+  const getBadgeVariant = () => {
+    switch (variant) {
+      case 'brand':
+        return 'status-badge-brand';
+      case 'success':
+        return 'status-badge-success';
+      case 'warning':
+        return 'status-badge-warning';
+      case 'error':
+        return 'status-badge-error';
+      default:
+        return 'status-badge-info';
+    }
+  };
+
   const getDotVariant = () => {
     switch (variant) {
+      case 'brand':
+        return 'status-dot-brand';
       case 'success':
         return 'status-dot-success';
       case 'warning':
@@ -23,7 +40,7 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({
   };
 
   return (
-    <div className="status-badge">
+    <div className={`status-badge ${getBadgeVariant()}`}>
       <div className={`status-dot ${getDotVariant()}`}></div>
       <span>{status}</span>
     </div>

--- a/src/components/charts/DonutChart.tsx
+++ b/src/components/charts/DonutChart.tsx
@@ -90,7 +90,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
       .append('path')
       .attr('d', arc)
       .attr('fill', (d) => colorScale(d.data.label))
-      .attr('stroke', 'white')
+      .attr('stroke', 'var(--surface-primary)')
       .attr('stroke-width', '2')
       .style('opacity', 0.9)
       .on('mouseover', function (event, d) {
@@ -117,7 +117,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
             </div>
             <div style="margin-top: 2px;">
               <span style="color: #9ca3af;">Процент:</span>
-              <span style="font-weight: 700; margin-left: 4px; color: ${percentage >= 20 ? '#10B981' : '#F59E0B'};">${percentage.toFixed(1)}%</span>
+              <span style="font-weight: 700; margin-left: 4px; color: ${percentage >= 20 ? 'var(--chart-accent-good)' : 'var(--chart-accent-warn)'};">${percentage.toFixed(1)}%</span>
             </div>
           `);
       })

--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Button, Form, InputGroup } from 'react-bootstrap';
+import { IconType } from 'react-icons';
+import { FaSearch, FaTimes } from 'react-icons/fa';
+
+type FilterBarProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+type FilterFieldProps = {
+  label?: string;
+  children: React.ReactNode;
+  className?: string;
+  grow?: boolean;
+};
+
+type SearchFilterProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  ariaLabel?: string;
+  className?: string;
+  icon?: IconType;
+};
+
+type FilterChipOption = {
+  value: string;
+  label: string;
+  icon?: IconType;
+};
+
+type FilterChipGroupProps = {
+  label: string;
+  options: FilterChipOption[];
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel?: string;
+  className?: string;
+};
+
+type ClearFiltersButtonProps = {
+  label: string;
+  onClick: () => void;
+  visible?: boolean;
+  reserveSpace?: boolean;
+  className?: string;
+};
+
+export const FilterBar: React.FC<FilterBarProps> = ({ children, className = '' }) => (
+  <div className={`filter-bar unified-filter-bar ${className}`.trim()}>
+    {children}
+  </div>
+);
+
+export const FilterField: React.FC<FilterFieldProps> = ({
+  label,
+  children,
+  className = '',
+  grow = false,
+}) => (
+  <div className={`filter-group unified-filter-field ${grow ? 'is-grow' : ''} ${className}`.trim()}>
+    {label && <label className="filter-label">{label}</label>}
+    {children}
+  </div>
+);
+
+export const SearchFilter: React.FC<SearchFilterProps> = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  className = '',
+  icon: Icon = FaSearch,
+}) => (
+  <FilterField label={label} className={`search-filter ${className}`.trim()} grow>
+    <InputGroup className="filter-input-group">
+      <InputGroup.Text>
+        <Icon className="text-secondary" />
+      </InputGroup.Text>
+      <Form.Control
+        type="search"
+        placeholder={placeholder}
+        aria-label={ariaLabel || label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="form-control filter-control"
+      />
+    </InputGroup>
+  </FilterField>
+);
+
+export const FilterChipGroup: React.FC<FilterChipGroupProps> = ({
+  label,
+  options,
+  value,
+  onChange,
+  ariaLabel,
+  className = '',
+}) => (
+  <FilterField label={label} className={`chip-filter ${className}`.trim()}>
+    <div className="filter-chip-row" role="group" aria-label={ariaLabel || label}>
+      {options.map((option) => {
+        const Icon = option.icon;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={`filter-chip ${value === option.value ? 'is-active' : ''}`}
+            onClick={() => onChange(option.value)}
+          >
+            {Icon && <Icon className="me-1" />}
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  </FilterField>
+);
+
+export const ClearFiltersButton: React.FC<ClearFiltersButtonProps> = ({
+  label,
+  onClick,
+  visible = true,
+  reserveSpace = true,
+  className = '',
+}) => (
+  <Button
+    variant="outline-secondary"
+    size="sm"
+    onClick={onClick}
+    className={`filter-clear-button ms-auto ${reserveSpace && !visible ? 'is-hidden' : ''} ${className}`.trim()}
+    disabled={!visible}
+    aria-hidden={!visible}
+  >
+    <FaTimes className="me-2" />
+    {label}
+  </Button>
+);

--- a/src/components/modal/Clients/ClientModal.tsx
+++ b/src/components/modal/Clients/ClientModal.tsx
@@ -185,7 +185,7 @@ const ClientModal = ({
                   </Form.Label>
                   <InputGroup>
                     <InputGroup.Text>
-                      <FaUser className="text-muted" />
+                      <FaUser className="client-modal-field-icon" />
                     </InputGroup.Text>
                     <Form.Control 
                       type="text" 
@@ -209,7 +209,7 @@ const ClientModal = ({
                   </Form.Label>
                   <InputGroup>
                     <InputGroup.Text>
-                      <FaUser className="text-muted" />
+                      <FaUser className="client-modal-field-icon" />
                     </InputGroup.Text>
                     <Form.Control 
                       type="text" 
@@ -240,7 +240,7 @@ const ClientModal = ({
                   <Form.Label>{t('phone')}</Form.Label>
                   <InputGroup>
                     <InputGroup.Text>
-                      <FaPhone className="text-muted" />
+                      <FaPhone className="client-modal-field-icon" />
                     </InputGroup.Text>
                     <Form.Control 
                       type="tel" 
@@ -264,7 +264,7 @@ const ClientModal = ({
                    <Form.Label>{t('telegram')}</Form.Label>
                    <InputGroup>
                      <InputGroup.Text>
-                       <FaTelegram className="text-primary" />
+                       <FaTelegram className="client-modal-field-icon" />
                      </InputGroup.Text>
                      <Form.Control 
                        type="text" 
@@ -290,7 +290,7 @@ const ClientModal = ({
                    <Form.Label>{t('instagram')}</Form.Label>
                    <InputGroup>
                      <InputGroup.Text>
-                       <FaInstagram className="text-danger" />
+                       <FaInstagram className="client-modal-field-icon" />
                      </InputGroup.Text>
                      <Form.Control 
                        type="text" 
@@ -314,7 +314,7 @@ const ClientModal = ({
                   <Form.Label>{t('source')}</Form.Label>
                   <InputGroup>
                     <InputGroup.Text>
-                      <FaTag className="text-muted" />
+                      <FaTag className="client-modal-field-icon" />
                     </InputGroup.Text>
                     <Form.Control 
                       type="text" 
@@ -350,11 +350,11 @@ const ClientModal = ({
                 )}
               </div>
               {address && (
-                <div className="mt-2 p-2 bg-light rounded">
+                <div className="modal-token-panel mt-2 p-2">
                   <small className="text-muted d-block">{t('selectedAddress')}:</small>
                   <div className="d-flex align-items-center">
-                    <FaMapMarkerAlt className="text-primary me-2" />
-                    <span className="text-dark">{address}</span>
+                    <FaMapMarkerAlt className="client-modal-field-icon me-2" />
+                    <span className="modal-selected-value">{address}</span>
                   </div>
                 </div>
               )}
@@ -375,8 +375,8 @@ const ClientModal = ({
         </Form>
       </Modal.Body>
       <Modal.Footer className="d-flex justify-content-between">
-        <div className="d-flex align-items-center text-muted small">
-          <span className="text-danger me-1">*</span>
+        <div className="client-modal-required-note">
+          <span className="client-modal-required-mark me-1">*</span>
           {t('requiredFields')}
         </div>
         <Button 

--- a/src/components/modal/Ingredients/AddIngredientModal.tsx
+++ b/src/components/modal/Ingredients/AddIngredientModal.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { Modal, Form, Button, Row, Col, Alert, Badge } from 'react-bootstrap';
 import useTranslation from 'next-translate/useTranslation';
-import { FaPlus, FaTag, FaUtensils, FaFlask, FaTint } from 'react-icons/fa';
+import { FaPlus, FaTag, FaUtensils } from 'react-icons/fa';
 import { Ingredient } from '../../../types/api';
 import SelectDropdown from '../../../components/SelectDropdown';
+import { getIngredientTypeOptions } from '../../../utils/ingredientTypes';
 
 interface AddIngredientModalProps {
   show: boolean;
@@ -78,11 +79,7 @@ const AddIngredientModal: React.FC<AddIngredientModalProps> = ({
     return () => window.clearTimeout(timeoutId);
   }, [ingredientName, onSearchGlobalIngredients, show]);
 
-  const ingredientTypeOptions = [
-    { value: 'base', label: t('base'), icon: FaUtensils },
-    { value: 'spice', label: t('spice'), icon: FaFlask },
-    { value: 'sauce', label: t('sauce'), icon: FaTint },
-  ];
+  const ingredientTypeOptions = useMemo(() => getIngredientTypeOptions(t), [t]);
 
   const validateForm = () => {
     const trimmedName = ingredientName.trim();
@@ -180,15 +177,6 @@ const AddIngredientModal: React.FC<AddIngredientModalProps> = ({
     }
   };
 
-  const getTypeIcon = (type: string) => {
-    const typeOption = ingredientTypeOptions.find(option => option.value === type);
-    if (typeOption) {
-      const IconComponent = typeOption.icon;
-      return <IconComponent className="me-1" />;
-    }
-    return <FaTag className="me-1" />;
-  };
-
   return (
     <Modal show={show} onHide={onClose} size="lg" className="add-ingredient-modal">
       <Modal.Header closeButton>
@@ -233,7 +221,7 @@ const AddIngredientModal: React.FC<AddIngredientModalProps> = ({
               </Form.Group>
 
               {(ingredientName.trim().length >= 2 || isSearching || searchResults.length > 0) && (
-                <div className="existing-ingredient-suggestions mt-2 p-2 bg-light rounded">
+                <div className="existing-ingredient-suggestions modal-token-panel mt-2 p-2">
                   {isSearching ? (
                     <small className="text-muted">{t('loading')}...</small>
                   ) : searchResults.length === 0 ? (
@@ -246,7 +234,7 @@ const AddIngredientModal: React.FC<AddIngredientModalProps> = ({
                           <button
                             key={ingredient.id}
                             type="button"
-                            className="btn btn-light existing-ingredient-suggestion d-flex align-items-center justify-content-between gap-2 text-start"
+                            className="btn modal-token-option existing-ingredient-suggestion d-flex align-items-center justify-content-between gap-2 text-start"
                             onClick={() => handleAddExisting(ingredient)}
                             disabled={isLoading || isAlreadyInList}
                           >
@@ -288,15 +276,18 @@ const AddIngredientModal: React.FC<AddIngredientModalProps> = ({
                   icon={FaTag}
                 />
 
-                <div className="mt-3 p-3 bg-light rounded">
-                  <h6 className="text-muted mb-2">{t('ingredientTypes')}:</h6>
+                <div className="modal-token-panel mt-3 p-3">
+                  <h6 className="modal-section-title mb-2">{t('ingredientTypes')}:</h6>
                   <div className="d-flex flex-wrap gap-2">
-                    {ingredientTypeOptions.map(option => (
-                      <div key={option.value} className="d-flex align-items-center">
-                        {getTypeIcon(option.value)}
-                        <small className="text-muted">{option.label}</small>
-                      </div>
-                    ))}
+                    {ingredientTypeOptions.map(option => {
+                      const IconComponent = option.icon;
+                      return (
+                        <div key={option.value} className="d-flex align-items-center">
+                          <IconComponent className="me-1" />
+                          <small className="text-muted">{option.label}</small>
+                        </div>
+                      );
+                    })}
                   </div>
                 </div>
               </Col>

--- a/src/components/modal/Prices/AddPriceModal.tsx
+++ b/src/components/modal/Prices/AddPriceModal.tsx
@@ -4,6 +4,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { FaPlus, FaDollarSign, FaWeight, FaRulerCombined, FaTag } from 'react-icons/fa';
 import { Ingredient } from '../../../types/api';
 import SelectDropdown from '../../../components/SelectDropdown';
+import { getUnitsForIngredientType } from '../../../utils/ingredientTypes';
 
 interface AddPriceModalProps {
   show: boolean;
@@ -57,26 +58,7 @@ const AddPriceModal: React.FC<AddPriceModalProps> = ({
       return;
     }
 
-    let availableUnits: string[] = [];
-    switch (selectedIngredient.type) {
-      case 'base':
-        availableUnits = ['kg', 'g'];
-        break;
-      case 'spice':
-        availableUnits = ['g'];
-        break;
-      case 'sauce':
-        availableUnits = ['ml'];
-        break;
-      case 'electricity':
-        availableUnits = ['hh'];
-        break;
-      case 'packing':
-        availableUnits = ['pieces'];
-        break;
-      default:
-        availableUnits = [];
-    }
+    const availableUnits = getUnitsForIngredientType(selectedIngredient.type);
     setUnits(availableUnits);
     setUnit(availableUnits[0] || '');
   };

--- a/src/components/modal/Recipe/CreateRecipeModal.tsx
+++ b/src/components/modal/Recipe/CreateRecipeModal.tsx
@@ -4,6 +4,7 @@ import { FaExclamationTriangle, FaLayerGroup, FaPlus, FaTrash } from 'react-icon
 import { Ingredient } from '../../../types/api';
 import SelectDropdown from '../../../components/SelectDropdown';
 import { formatCount } from '../../../utils/pluralize';
+import { getUnitsForIngredientType } from '../../../utils/ingredientTypes';
 
 type UnitOption = {
   value: string;
@@ -29,20 +30,7 @@ type CreateRecipeModalProps = {
 const getUnitsForIngredient = (ingredient?: Ingredient) => {
   if (!ingredient) return [];
 
-  switch (ingredient.type) {
-    case 'base':
-      return ['kg', 'g'];
-    case 'spice':
-      return ['g'];
-    case 'sauce':
-      return ['ml'];
-    case 'electricity':
-      return ['hh'];
-    case 'packing':
-      return ['pieces'];
-    default:
-      return [];
-  }
+  return getUnitsForIngredientType(ingredient.type);
 };
 
 const CreateRecipeModal: React.FC<CreateRecipeModalProps> = ({

--- a/src/components/modal/Recipe/EditRecipeModal.tsx
+++ b/src/components/modal/Recipe/EditRecipeModal.tsx
@@ -5,6 +5,7 @@ import fetcher from '../../../utils/fetcher';
 import { useAuth } from '../../../utils/authContext';
 import { Ingredient, Recipe } from '../../../types/api';
 import SelectDropdown from '../../../components/SelectDropdown';
+import { getUnitsForIngredientType } from '../../../utils/ingredientTypes';
 
 const EditRecipeModal = ({ show, onHide, recipe, ingredients, t, onDeleteRecipe, onCloneRecipe, onUpdateRecipe }) => {
   const { auth } = useAuth();
@@ -34,26 +35,7 @@ const EditRecipeModal = ({ show, onHide, recipe, ingredients, t, onDeleteRecipe,
     const selectedIngredient = ingredients.find((ingredient: Ingredient) => ingredient.id === parseInt(ingredientId));
     if (!selectedIngredient) return;
 
-    let units = [];
-    switch (selectedIngredient.type) {
-      case 'base':
-        units = ['kg', 'g'];
-        break;
-      case 'spice':
-        units = ['g'];
-        break;
-      case 'sauce':
-        units = ['ml'];
-        break;
-      case 'electricity':
-        units = ['hh'];
-        break;
-      case 'packing':
-        units = ['pieces'];
-        break;
-      default:
-        units = [];
-    }
+    const units = getUnitsForIngredientType(selectedIngredient.type);
     setUnits(units.map(unit => ({ value: unit, label: t(unit) })));
     setUnit(units[0] ? { value: units[0], label: t(units[0]) } : null);
   };
@@ -168,9 +150,9 @@ const EditRecipeModal = ({ show, onHide, recipe, ingredients, t, onDeleteRecipe,
   };
 
   return (
-    <Modal show={show} onHide={onHide}>
+    <Modal show={show} onHide={onHide} className="recipe-edit-modal">
       <Modal.Header closeButton>
-        <Button variant="danger" onClick={onDeleteRecipe} style={{ position: 'relative', background: 'transparent', color: 'darkred' }}>
+        <Button variant="outline-danger" onClick={onDeleteRecipe} className="btn-icon-small me-2" aria-label={t('delete')}>
           <FaTrash />
         </Button>
         <Modal.Title>{t('editRecipe')}</Modal.Title>
@@ -269,7 +251,7 @@ const EditRecipeModal = ({ show, onHide, recipe, ingredients, t, onDeleteRecipe,
                 </ListGroup>
               </div>
             ) : (
-              <div className="text-center py-3 mt-3 bg-light rounded">
+              <div className="modal-empty-state text-center py-3 mt-3">
                 <div className="text-muted">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" className="mb-2" viewBox="0 0 16 16">
                     <path d="M8 1a2.5 2.5 0 0 1 2.5 2.5V4h-5v-.5A2.5 2.5 0 0 1 8 1zm3.5 3v-.5a3.5 3.5 0 1 0-7 0V4H1v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V4h-3.5zM2 5h12v9a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5z"/>

--- a/src/pages/clients.tsx
+++ b/src/pages/clients.tsx
@@ -3,17 +3,18 @@ import useSWR from 'swr';
 import fetcher from '../utils/fetcher';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
-import { Button, InputGroup, FormControl, Col } from 'react-bootstrap';
+import { Button, Col } from 'react-bootstrap';
 import ClientModal from '../components/modal/Clients/ClientModal';
 import ClientCardSkeleton from '../components/skeletons/ClientCardSkeleton';
 import EmptyState from '../components/EmptyState';
-import { FaPlus, FaUsers, FaSearch, FaTimes, FaEdit } from 'react-icons/fa';
+import { FaPlus, FaUsers, FaEdit } from 'react-icons/fa';
 import { useAuth } from '../utils/authContext';
 import { useNotification } from '../hooks/useNotification';
 import { Client } from '../types/api';
 import { getMapboxToken } from '../utils/runtimeConfig';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+import { ClearFiltersButton, FilterBar, SearchFilter } from '../components/filters/FilterBar';
 
 const Clients = ({ mapboxToken }) => {
   const { t, lang } = useTranslation('common');
@@ -166,33 +167,20 @@ const Clients = ({ mapboxToken }) => {
       </div>
 
       {/* Search Section */}
-      <div className="filter-bar">
-        <div className="filter-group flex-grow-1">
-          <label className="filter-label">{t('search')}</label>
-          <InputGroup>
-            <InputGroup.Text className="bg-transparent">
-              <FaSearch className="text-secondary" />
-            </InputGroup.Text>
-            <FormControl
-              placeholder={t('searchClientsPlaceholder')}
-              aria-label={t('search')}
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="form-control"
-            />
-            {searchTerm && (
-              <Button
-                variant="outline-secondary"
-                size="sm"
-                onClick={clearSearch}
-                className="ms-2"
-              >
-                <FaTimes />
-              </Button>
-            )}
-          </InputGroup>
-        </div>
-      </div>
+      <FilterBar>
+        <SearchFilter
+          label={t('search')}
+          value={searchTerm}
+          onChange={setSearchTerm}
+          placeholder={t('searchClientsPlaceholder')}
+          ariaLabel={t('search')}
+        />
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={clearSearch}
+          visible={!!searchTerm}
+        />
+      </FilterBar>
 
       {/* Clients Grid */}
       <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback, useState } from 'react';
-import { Container, Row, Col, Card, Table, Button, Badge, ProgressBar } from 'react-bootstrap';
+import { Container, Row, Col, Card, Table, Button, ProgressBar } from 'react-bootstrap';
 import useSWR from 'swr';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
@@ -12,6 +12,7 @@ import StatusModal from '../components/modal/Orders/StatusModal';
 import DeleteModal from '../components/modal/Orders/DeleteModal';
 import { MetricCard } from '../components/MetricCard';
 import { DonutChart } from '../components/charts';
+import StatusBadge from '../components/StatusBadge';
 import { swrConfigs } from '../utils/swrConfig';
 import {
   FaBook,
@@ -39,6 +40,32 @@ import { formatDate } from '../utils/contactHelpers';
 import { useNotification } from '../hooks/useNotification';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+
+type DashboardStatusVariant = 'brand' | 'success' | 'warning' | 'error' | 'info';
+
+const dashboardChartColors = [
+  'var(--chart-accent-brand)',
+  'var(--chart-accent-warn)',
+  'var(--chart-accent-info)',
+  'var(--chart-accent-good)',
+  'var(--chart-accent-danger)',
+] as const;
+
+const getOrderStatusVariant = (status: string): DashboardStatusVariant => {
+  switch (status) {
+    case 'new':
+      return 'brand';
+    case 'in_progress':
+      return 'warning';
+    case 'finished':
+    case 'completed':
+      return 'success';
+    case 'canceled':
+      return 'error';
+    default:
+      return 'info';
+  }
+};
 
 const Dashboard = () => {
   const { t } = useTranslation('common');
@@ -645,11 +672,11 @@ const Dashboard = () => {
                 {orderStats.total > 0 ? (
                   <DonutChart
                     data={[
-                      { label: t('new'), value: orderStats.new, color: '#8B2635' },
-                      { label: t('inProgress'), value: orderStats.in_progress, color: '#F59E0B' },
-                      { label: t('ready'), value: orderStats.ready, color: '#9C27B0' },
-                      { label: t('finished'), value: orderStats.finished, color: '#10B981' },
-                      { label: t('canceled'), value: orderStats.canceled, color: '#EF4444' }
+                      { label: t('new'), value: orderStats.new, color: 'var(--chart-accent-brand)' },
+                      { label: t('inProgress'), value: orderStats.in_progress, color: 'var(--chart-accent-warn)' },
+                      { label: t('ready'), value: orderStats.ready, color: 'var(--chart-accent-info)' },
+                      { label: t('finished'), value: orderStats.finished, color: 'var(--chart-accent-good)' },
+                      { label: t('canceled'), value: orderStats.canceled, color: 'var(--chart-accent-danger)' }
                     ].filter(d => d.value > 0)}
                     size={200}
                     innerRadius={60}
@@ -678,7 +705,7 @@ const Dashboard = () => {
                     data={ingredientTypesData.labels.map((label, i) => ({
                       label,
                       value: ingredientTypesData.datasets[0].data[i],
-                      color: ['#8B2635', '#F59E0B', '#10B981', '#0EA5E9', '#9C27B0'][i % 5]
+                      color: dashboardChartColors[i % dashboardChartColors.length]
                     }))}
                     size={200}
                     innerRadius={60}
@@ -705,9 +732,9 @@ const Dashboard = () => {
                 {profitChartData && profitData && profitData.total_revenue > 0 ? (
                   <DonutChart
                     data={[
-                      { label: t('totalRevenue'), value: profitData.total_revenue, color: '#10B981' },
-                      { label: t('totalCosts'), value: profitData.total_costs, color: '#F59E0B' },
-                      { label: t('totalProfit'), value: Math.abs(profitData.total_profit), color: profitData.total_profit >= 0 ? '#0EA5E9' : '#EF4444' }
+                      { label: t('totalRevenue'), value: profitData.total_revenue, color: 'var(--chart-accent-good)' },
+                      { label: t('totalCosts'), value: profitData.total_costs, color: 'var(--chart-accent-warn)' },
+                      { label: t('totalProfit'), value: Math.abs(profitData.total_profit), color: profitData.total_profit >= 0 ? 'var(--chart-accent-info)' : 'var(--chart-accent-danger)' }
                     ]}
                     size={200}
                     innerRadius={60}
@@ -761,10 +788,7 @@ const Dashboard = () => {
                       <tbody>
                         {(dashboardStats?.recent_orders?.length ? dashboardStats.recent_orders : pendingOrders).map((order) => {
                           const isApiOrder = 'client_name' in order;
-                          const statusVariant = order.status === 'new' ? 'primary' : 
-                                                order.status === 'in_progress' ? 'warning' : 
-                                                order.status === 'ready' ? 'info' : 
-                                                order.status === 'completed' ? 'success' : 'danger';
+                          const statusVariant = getOrderStatusVariant(order.status);
                           
                           return (
                             <tr key={order.id}>
@@ -779,9 +803,7 @@ const Dashboard = () => {
                                 }
                               </td>
                               <td>
-                                <Badge bg={statusVariant} className="px-2 py-1">
-                                  {t(order.status)}
-                                </Badge>
+                                <StatusBadge status={t(order.status)} variant={statusVariant} />
                               </td>
                               <td className="fw-bold text-success">
                                 {isApiOrder 

--- a/src/pages/ingredients.tsx
+++ b/src/pages/ingredients.tsx
@@ -1,16 +1,19 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import useSWR from 'swr';
-import { Form, Button, Table, InputGroup } from 'react-bootstrap';
+import { Button, Table } from 'react-bootstrap';
 import useTranslation from 'next-translate/useTranslation';
 import fetcher from '../utils/fetcher';
 import EmptyState from '../components/EmptyState';
+import IngredientTypeBadge from '../components/IngredientTypeBadge';
 import { useRouter } from 'next/router';
 import { useAuth, withAuth } from '../utils/authContext';
-import { FaPlus, FaTimes, FaTag, FaSearch, FaList, FaFlask, FaUtensils, FaTint, FaHistory } from 'react-icons/fa';
+import { FaPlus, FaList, FaHistory } from 'react-icons/fa';
 import AddIngredientModal from '../components/modal/Ingredients/AddIngredientModal';
 import { WorkspaceIngredient } from '../types/api';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+import { getIngredientTypeOptions } from '../utils/ingredientTypes';
+import { ClearFiltersButton, FilterBar, FilterChipGroup, SearchFilter } from '../components/filters/FilterBar';
 
 type PriceStateFilter = 'all' | 'missing' | 'priced';
 
@@ -28,27 +31,13 @@ const Ingredients: React.FC = () => {
   const [showAddModal, setShowAddModal] = useState(false);
   const router = useRouter();
 
-  const ingredientTypeOptions = [
-    { value: 'all', label: t('allTypes'), icon: FaList },
-    { value: 'base', label: t('base'), icon: FaUtensils },
-    { value: 'spice', label: t('spice'), icon: FaFlask },
-    { value: 'sauce', label: t('sauce'), icon: FaTint },
-  ];
+  const ingredientTypeOptions = useMemo(() => getIngredientTypeOptions(t, { includeAll: true }), [t]);
 
   const priceStateOptions: { value: PriceStateFilter; label: string }[] = [
     { value: 'all', label: t('allPriceStates') },
     { value: 'missing', label: t('missingPrice') },
     { value: 'priced', label: t('hasPrice') },
   ];
-
-  const getTypeIcon = (type: string) => {
-    const typeOption = ingredientTypeOptions.find(option => option.value === type);
-    if (typeOption) {
-      const IconComponent = typeOption.icon;
-      return <IconComponent className="me-1" />;
-    }
-    return <FaTag className="me-1" />;
-  };
 
   const ingredients = workspaceIngredients?.map((workspaceIngredient) => workspaceIngredient.ingredient) || [];
 
@@ -166,68 +155,35 @@ const Ingredients: React.FC = () => {
       </div>
 
       {/* Filter Section */}
-      <div className="filter-bar">
-        <div className="filter-group">
-          <label className="filter-label">{t('search')}</label>
-          <InputGroup>
-            <InputGroup.Text className="bg-transparent">
-              <FaSearch className="text-secondary" />
-            </InputGroup.Text>
-            <Form.Control
-              type="text"
-              placeholder={t('filterIngredients')}
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              className="form-control"
-            />
-          </InputGroup>
-        </div>
-        <div className="filter-group">
-          <label className="filter-label">{t('type')}</label>
-          <div className="filter-chip-row" role="group" aria-label={t('type')}>
-            {ingredientTypeOptions.map((option) => {
-              const IconComponent = option.icon;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  className={`filter-chip ${filterType === option.value ? 'is-active' : ''}`}
-                  onClick={() => setFilterType(option.value)}
-                >
-                  <IconComponent className="me-1" />
-                  {option.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-        <div className="filter-group">
-          <label className="filter-label">{t('priceState')}</label>
-          <div className="filter-chip-row" role="group" aria-label={t('priceState')}>
-            {priceStateOptions.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className={`filter-chip ${filterPriceState === option.value ? 'is-active' : ''}`}
-                onClick={() => setFilterPriceState(option.value)}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        </div>
-        {hasActiveFilters && (
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={clearFilters}
-            className="ms-auto"
-          >
-            <FaTimes className="me-2" />
-            {t('clear')}
-          </Button>
-        )}
-      </div>
+      <FilterBar className="ingredients-filter-bar">
+        <SearchFilter
+          label={t('search')}
+          value={filter}
+          onChange={setFilter}
+          placeholder={t('filterIngredients')}
+        />
+        <FilterChipGroup
+          label={t('type')}
+          options={ingredientTypeOptions}
+          value={filterType}
+          onChange={setFilterType}
+          ariaLabel={t('type')}
+          className="ingredients-chip-filter"
+        />
+        <FilterChipGroup
+          label={t('priceState')}
+          options={priceStateOptions}
+          value={filterPriceState}
+          onChange={(value) => setFilterPriceState(value as PriceStateFilter)}
+          ariaLabel={t('priceState')}
+          className="ingredients-chip-filter"
+        />
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={clearFilters}
+          visible={hasActiveFilters}
+        />
+      </FilterBar>
 
       {/* Ingredients List */}
       {isLoading ? (
@@ -258,14 +214,10 @@ const Ingredients: React.FC = () => {
                 <tr key={workspaceIngredient.id}>
                   <td className="fw-medium" data-label={t('name')}>{workspaceIngredient.ingredient.name}</td>
                   <td data-label={t('type')}>
-                    <span className={`badge ${
-                      workspaceIngredient.ingredient.type === 'base' ? 'badge-primary' :
-                      workspaceIngredient.ingredient.type === 'spice' ? 'badge-warning' :
-                      workspaceIngredient.ingredient.type === 'sauce' ? 'badge-info' : 'badge-secondary'
-                    }`}>
-                      {getTypeIcon(workspaceIngredient.ingredient.type)}
-                      {t(workspaceIngredient.ingredient.type)}
-                    </span>
+                    <IngredientTypeBadge
+                      type={workspaceIngredient.ingredient.type}
+                      label={t(workspaceIngredient.ingredient.type)}
+                    />
                   </td>
                   <td data-label={t('latestPrice')}>
                     {workspaceIngredient.latest_price ? (

--- a/src/pages/orders.tsx
+++ b/src/pages/orders.tsx
@@ -16,9 +16,10 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../utils/authContext';
 import { useNotification } from '../hooks/useNotification';
 import { Order, OrderItem, Client, Product, ORDER_STATUSES } from '../types/api';
-import { FaSync, FaPencilAlt, FaTrash, FaPlus, FaShoppingCart, FaTimes } from "react-icons/fa";
+import { FaSync, FaPencilAlt, FaTrash, FaPlus, FaShoppingCart } from "react-icons/fa";
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+import { ClearFiltersButton, FilterBar } from '../components/filters/FilterBar';
 
 const Orders = () => {
   const { t } = useTranslation("common");
@@ -337,7 +338,7 @@ const Orders = () => {
       </div>
 
       {/* Filter Section */}
-      <div className="filter-bar">
+      <FilterBar>
         <div className="filter-group">
           <SelectDropdown
             options={statusOptions}
@@ -358,18 +359,12 @@ const Orders = () => {
             label={t('client')}
           />
         </div>
-        {hasActiveFilters && (
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={clearFilters}
-            className="ms-auto"
-          >
-            <FaTimes className="me-2" />
-            {t('clear')}
-          </Button>
-        )}
-      </div>
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={clearFilters}
+          visible={!!hasActiveFilters}
+        />
+      </FilterBar>
 
       {/* Orders Table */}
       {isLoading ? (
@@ -425,7 +420,7 @@ const Orders = () => {
                     <StatusBadge
                       status={t(order.status)}
                       variant={
-                        order.status === 'new' ? 'info' :
+                        order.status === 'new' ? 'brand' :
                         order.status === 'in_progress' ? 'warning' :
                         order.status === 'canceled' ? 'error' :
                         order.status === 'ready' ? 'info' : 'success'

--- a/src/pages/prices.tsx
+++ b/src/pages/prices.tsx
@@ -5,14 +5,16 @@ import useTranslation from 'next-translate/useTranslation';
 import { Form, Button, Table } from 'react-bootstrap';
 import TableSkeleton from '../components/skeletons/TableSkeleton';
 import EmptyState from '../components/EmptyState';
+import IngredientTypeBadge from '../components/IngredientTypeBadge';
 import { useRouter } from 'next/router';
-import { FaPlus, FaDollarSign, FaTimes, FaUtensils, FaFlask, FaTint, FaTag, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa';
+import { FaPlus, FaDollarSign, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa';
 import AddPriceModal from '../components/modal/Prices/AddPriceModal';
 import { useAuth } from '../utils/authContext';
 import { Ingredient, Price, WorkspaceIngredient } from '../types/api';
 import SelectDropdown from '../components/SelectDropdown';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+import { ClearFiltersButton, FilterBar, FilterField } from '../components/filters/FilterBar';
 
 const formatLocalDateInputValue = (dateValue: string) => {
   const date = new Date(dateValue);
@@ -50,22 +52,6 @@ const Prices = () => {
   const [showAddModal, setShowAddModal] = useState(false);
 
   const router = useRouter();
-
-  // Ingredient type options with icons
-  const ingredientTypeOptions = [
-    { value: 'base', label: t('base'), icon: FaUtensils },
-    { value: 'spice', label: t('spice'), icon: FaFlask },
-    { value: 'sauce', label: t('sauce'), icon: FaTint },
-  ];
-
-  const getTypeIcon = (type: string) => {
-    const typeOption = ingredientTypeOptions.find(option => option.value === type);
-    if (typeOption) {
-      const IconComponent = typeOption.icon;
-      return <IconComponent className="me-1" />;
-    }
-    return <FaTag className="me-1" />;
-  };
 
   useEffect(() => {
     if (router.locale !== lang) {
@@ -235,7 +221,7 @@ const Prices = () => {
       </div>
 
       {/* Filter Section */}
-      <div className="filter-bar">
+      <FilterBar>
         <div className="filter-group">
           <SelectDropdown
             value={ingredientOptions.find(option => String(option.value) === filterIngredientId) || null}
@@ -246,27 +232,20 @@ const Prices = () => {
             label={t('ingredient')}
           />
         </div>
-        <div className="filter-group">
-          <label className="filter-label">{t('date')}</label>
+        <FilterField label={t('date')}>
           <Form.Control
             type="date"
             value={filterDate}
             onChange={(e) => setFilterDate(e.target.value)}
-            className="form-control"
+            className="form-control filter-control"
           />
-        </div>
-        {hasActiveFilters && (
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={clearFilters}
-            className="ms-auto"
-          >
-            <FaTimes className="me-2" />
-            {t('clear')}
-          </Button>
-        )}
-      </div>
+        </FilterField>
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={clearFilters}
+          visible={!!hasActiveFilters}
+        />
+      </FilterBar>
 
       <div className="mobile-sort-bar">
         <div className="filter-group">
@@ -328,14 +307,7 @@ const Prices = () => {
               {filteredPrices.map((price: Price) => (
               <tr key={price.id}>
                 <td data-label={t('ingredientType')}>
-                  <span className={`badge badge-${
-                    price.ingredient.type === 'base' ? 'primary' :
-                    price.ingredient.type === 'spice' ? 'warning' :
-                    price.ingredient.type === 'sauce' ? 'info' : 'secondary'
-                  }`}>
-                    {getTypeIcon(price.ingredient.type)}
-                    {t(price.ingredient.type)}
-                  </span>
+                  <IngredientTypeBadge type={price.ingredient.type} label={t(price.ingredient.type)} />
                 </td>
                 <td data-label={t('ingredientName')}>{price.ingredient.name}</td>
                 <td className="fw-semibold" data-label={t('price')}>{price.price} {t("currency")}</td>

--- a/src/pages/products.tsx
+++ b/src/pages/products.tsx
@@ -8,7 +8,7 @@ import { Button } from 'react-bootstrap';
 import { SingleValue } from 'react-select';
 import ProductModal from '../components/modal/Products/ProductModal';
 import PackageModal from '../components/modal/Products/PackageModal';
-import { FaPlus, FaTag, FaTimes } from 'react-icons/fa';
+import { FaPlus, FaTag } from 'react-icons/fa';
 import ProductCard from '../components/ProductCard';
 import ProductCardSkeleton from '../components/skeletons/ProductCardSkeleton';
 import EmptyState from '../components/EmptyState';
@@ -19,6 +19,7 @@ import { useNotification } from '../hooks/useNotification';
 import SelectDropdown from '../components/SelectDropdown';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
+import { ClearFiltersButton, FilterBar } from '../components/filters/FilterBar';
 
 const Products = () => {
   const { t } = useTranslation('common');
@@ -230,6 +231,7 @@ const Products = () => {
   const recipeOptions = recipes?.map(recipe => ({ value: recipe.id, label: recipe.name })) || [];
   const packageOptions = packages?.map(pkg => ({ value: pkg.id, label: pkg.name })) || [];
   const productOptions = products?.map(product => ({ value: product.id, label: product.name })) || [];
+  const hasActiveFilters = !!(selectedRecipe || selectedPackage || selectedProduct);
 
   // Проверяем наличие ошибок
   const hasError = productsError || recipesError || packagesError;
@@ -277,7 +279,7 @@ const Products = () => {
       </div>
 
       {/* Filter Section */}
-      <div className="filter-bar products-filter-bar">
+      <FilterBar className="products-filter-bar">
         <div className="filter-group">
           <SelectDropdown
             options={recipeOptions}
@@ -298,22 +300,16 @@ const Products = () => {
             label={t('product')}
           />
         </div>
-        {selectedRecipe || selectedPackage || selectedProduct ? (
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={() => {
-              setSelectedRecipe(null);
-              setSelectedPackage(null);
-              setSelectedProduct(null);
-            }}
-            className="ms-auto"
-          >
-            <FaTimes className="me-2" />
-            {t('clear')}
-          </Button>
-        ) : null}
-      </div>
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={() => {
+            setSelectedRecipe(null);
+            setSelectedPackage(null);
+            setSelectedProduct(null);
+          }}
+          visible={hasActiveFilters}
+        />
+      </FilterBar>
 
       {!isLoading && (
         <div className="package-chip-strip" aria-label={t('package')}>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -4,6 +4,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { Form, Button, Alert, InputGroup } from 'react-bootstrap';
 import { useAuth, withAuth } from '../utils/authContext';
 import { FaUser, FaLock, FaEye, FaEyeSlash, FaShieldAlt, FaCalendarAlt, FaIdCard, FaEnvelope } from 'react-icons/fa';
+import StatusBadge from '../components/StatusBadge';
 
 const Profile = () => {
   const { t } = useTranslation('common');
@@ -88,7 +89,7 @@ const Profile = () => {
       <div className="profile-grid">
         {/* Account Info Card */}
         <div className="profile-card">
-          <div className="profile-card-header bg-primary">
+          <div className="profile-card-header">
             <h5 className="profile-card-title">
               <FaIdCard className="me-2" />
               {t('accountInfo')}
@@ -119,7 +120,7 @@ const Profile = () => {
                 {t('accountStatus')}
               </div>
               <div className="info-value">
-                <span className="badge badge-success">{t('active')}</span>
+                <StatusBadge status={t('active')} variant="success" />
               </div>
             </div>
 
@@ -137,8 +138,8 @@ const Profile = () => {
 
         {/* Change Password Card */}
         <div className="profile-card profile-card-large">
-          <div className="profile-card-header bg-warning">
-            <h5 className="profile-card-title text-primary">
+          <div className="profile-card-header">
+            <h5 className="profile-card-title">
               <FaLock className="me-2" />
               {t('changePassword')}
             </h5>
@@ -151,7 +152,10 @@ const Profile = () => {
                     <FaLock className="me-2 text-primary" />
                     {t('currentPassword')} <span className="text-error">*</span>
                   </Form.Label>
-                  <InputGroup>
+                  <InputGroup className="profile-password-group">
+                    <InputGroup.Text>
+                      <FaLock />
+                    </InputGroup.Text>
                     <Form.Control
                       type={showCurrentPassword ? "text" : "password"}
                       value={currentPassword}
@@ -161,6 +165,7 @@ const Profile = () => {
                     />
                     <Button
                       variant="outline-secondary"
+                      className="profile-password-toggle"
                       type="button"
                       onClick={() => setShowCurrentPassword(!showCurrentPassword)}
                     >
@@ -175,7 +180,10 @@ const Profile = () => {
                       <FaLock className="me-2 text-primary" />
                       {t('newPassword')} <span className="text-error">*</span>
                     </Form.Label>
-                    <InputGroup>
+                    <InputGroup className="profile-password-group">
+                      <InputGroup.Text>
+                        <FaLock />
+                      </InputGroup.Text>
                       <Form.Control
                         type={showNewPassword ? "text" : "password"}
                         value={newPassword}
@@ -186,6 +194,7 @@ const Profile = () => {
                       />
                       <Button
                         variant="outline-secondary"
+                        className="profile-password-toggle"
                         type="button"
                         onClick={() => setShowNewPassword(!showNewPassword)}
                       >
@@ -202,7 +211,10 @@ const Profile = () => {
                       <FaLock className="me-2 text-primary" />
                       {t('confirmPassword')} <span className="text-error">*</span>
                     </Form.Label>
-                    <InputGroup>
+                    <InputGroup className="profile-password-group">
+                      <InputGroup.Text>
+                        <FaLock />
+                      </InputGroup.Text>
                       <Form.Control
                         type={showConfirmPassword ? "text" : "password"}
                         value={confirmPassword}
@@ -212,6 +224,7 @@ const Profile = () => {
                       />
                       <Button
                         variant="outline-secondary"
+                        className="profile-password-toggle"
                         type="button"
                         onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                       >

--- a/src/pages/recipes.tsx
+++ b/src/pages/recipes.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import fetcher from '../utils/fetcher';
 import useTranslation from 'next-translate/useTranslation';
-import { Button, Form } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import EditRecipeModal from '../components/modal/Recipe/EditRecipeModal';
 import CreateRecipeModal from '../components/modal/Recipe/CreateRecipeModal';
 import RecipeCalculator from '../components/calculator/RecipeCalculator';
@@ -11,12 +11,13 @@ import EmptyState from '../components/EmptyState';
 import { useRouter } from 'next/router';
 import { useAuth, withAuth } from '../utils/authContext';
 import { useNotification } from '../hooks/useNotification';
-import { FaPlus, FaUtensils, FaTimes, FaCalculator, FaEdit, FaExclamationTriangle } from 'react-icons/fa';
+import { FaPlus, FaUtensils, FaCalculator, FaEdit, FaExclamationTriangle } from 'react-icons/fa';
 import SelectDropdown from '../components/SelectDropdown';
 import { formatCount } from '../utils/pluralize';
 import { useWorkspace } from '../utils/workspaceContext';
 import { workspaceFetcher, workspaceKey } from '../utils/workspaceSWR';
 import { WorkspaceIngredient } from '../types/api';
+import { ClearFiltersButton, FilterBar, SearchFilter } from '../components/filters/FilterBar';
 
 const Recipes: React.FC = () => {
   const { auth } = useAuth();
@@ -399,16 +400,13 @@ const Recipes: React.FC = () => {
         </Button>
       </div>
 
-      <div className="recipe-filter-strip">
-        <div className="filter-group">
-          <Form.Label>{t('searchRecipes')}</Form.Label>
-          <Form.Control
-            type="search"
-            value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
-            placeholder={t('searchByName')}
-          />
-        </div>
+      <FilterBar className="recipe-filter-strip">
+        <SearchFilter
+          label={t('searchRecipes')}
+          value={searchTerm}
+          onChange={setSearchTerm}
+          placeholder={t('searchByName')}
+        />
         <div className="filter-group">
           <SelectDropdown
             value={
@@ -433,18 +431,12 @@ const Recipes: React.FC = () => {
         <div className="recipe-filter-summary">
           {filteredRecipes.length} {t('of')} {formatCount(t, recipeNames?.length || 0, 'recipe')}
         </div>
-        {hasActiveFilters && (
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={clearFilters}
-            className="ms-auto"
-          >
-            <FaTimes className="me-2" />
-            {t('clear')}
-          </Button>
-        )}
-      </div>
+        <ClearFiltersButton
+          label={t('clear')}
+          onClick={clearFilters}
+          visible={!!hasActiveFilters}
+        />
+      </FilterBar>
 
       {/* Recipes Grid */}
       {isLoading ? (

--- a/src/styles/batchvault-adapter.css
+++ b/src/styles/batchvault-adapter.css
@@ -52,6 +52,44 @@
   --batchvault-copper: #c97845;
   --batchvault-copper-soft: #fff4ec;
   --batchvault-burgundy-soft: rgba(139, 38, 53, 0.1);
+  --chart-accent-brand: #8b2635;
+  --chart-accent-warn: #c97845;
+  --chart-accent-info: #4b7b91;
+  --chart-accent-good: #3f8f68;
+  --chart-accent-danger: #b95353;
+  --status-info-bg: rgba(75, 123, 145, 0.1);
+  --status-info-border: rgba(75, 123, 145, 0.28);
+  --status-info-text: #315f73;
+  --status-brand-bg: rgba(139, 38, 53, 0.1);
+  --status-brand-border: rgba(139, 38, 53, 0.28);
+  --status-brand-text: #7a1f2c;
+  --status-warning-bg: rgba(201, 120, 69, 0.12);
+  --status-warning-border: rgba(201, 120, 69, 0.32);
+  --status-warning-text: #8c552e;
+  --status-success-bg: rgba(63, 143, 104, 0.12);
+  --status-success-border: rgba(63, 143, 104, 0.32);
+  --status-success-text: #2f6f51;
+  --status-error-bg: rgba(185, 83, 83, 0.12);
+  --status-error-border: rgba(185, 83, 83, 0.32);
+  --status-error-text: #8e3f3f;
+  --ingredient-base-bg: var(--status-brand-bg);
+  --ingredient-base-border: var(--status-brand-border);
+  --ingredient-base-text: var(--status-brand-text);
+  --ingredient-spice-bg: var(--status-warning-bg);
+  --ingredient-spice-border: var(--status-warning-border);
+  --ingredient-spice-text: var(--status-warning-text);
+  --ingredient-sauce-bg: var(--status-info-bg);
+  --ingredient-sauce-border: var(--status-info-border);
+  --ingredient-sauce-text: var(--status-info-text);
+  --ingredient-packing-bg: rgba(75, 123, 145, 0.08);
+  --ingredient-packing-border: rgba(75, 123, 145, 0.22);
+  --ingredient-packing-text: #3c6577;
+  --ingredient-electricity-bg: rgba(201, 120, 69, 0.08);
+  --ingredient-electricity-border: rgba(201, 120, 69, 0.22);
+  --ingredient-electricity-text: #7a5433;
+  --ingredient-other-bg: rgba(100, 116, 139, 0.1);
+  --ingredient-other-border: rgba(100, 116, 139, 0.28);
+  --ingredient-other-text: #475569;
 
   /* Application typography preset. */
   --font-body: var(--font-sans);
@@ -86,9 +124,9 @@
   --surface-secondary: #1a1d21;
   --surface-tertiary: #2a2d32;
   --surface-overlay: rgba(0, 0, 0, 0.62);
-  --text-primary: #f5f5f5;
-  --text-secondary: rgba(245, 245, 245, 0.72);
-  --text-tertiary: rgba(245, 245, 245, 0.5);
+  --text-primary: rgba(245, 245, 245, 0.86);
+  --text-secondary: rgba(245, 245, 245, 0.66);
+  --text-tertiary: rgba(245, 245, 245, 0.46);
   --text-inverse: #ffffff;
   --border-primary: rgba(255, 255, 255, 0.08);
   --border-secondary: rgba(255, 255, 255, 0.12);
@@ -112,6 +150,70 @@
   --danger-bg: rgba(220, 38, 38, 0.15);
   --batchvault-copper-soft: rgba(201, 120, 69, 0.14);
   --batchvault-burgundy-soft: rgba(139, 38, 53, 0.22);
+  --chart-accent-brand: #9a5c65;
+  --chart-accent-warn: #a97945;
+  --chart-accent-info: #628493;
+  --chart-accent-good: #5f8f72;
+  --chart-accent-danger: #a76464;
+  --status-info-bg: rgba(98, 132, 147, 0.16);
+  --status-info-border: rgba(98, 132, 147, 0.34);
+  --status-info-text: rgba(210, 226, 233, 0.78);
+  --status-brand-bg: rgba(154, 92, 101, 0.17);
+  --status-brand-border: rgba(154, 92, 101, 0.36);
+  --status-brand-text: rgba(232, 203, 207, 0.78);
+  --status-warning-bg: rgba(169, 121, 69, 0.17);
+  --status-warning-border: rgba(169, 121, 69, 0.36);
+  --status-warning-text: rgba(231, 207, 178, 0.78);
+  --status-success-bg: rgba(95, 143, 114, 0.17);
+  --status-success-border: rgba(95, 143, 114, 0.36);
+  --status-success-text: rgba(209, 229, 217, 0.78);
+  --status-error-bg: rgba(167, 100, 100, 0.17);
+  --status-error-border: rgba(167, 100, 100, 0.36);
+  --status-error-text: rgba(232, 205, 205, 0.78);
+  --ingredient-base-bg: var(--status-brand-bg);
+  --ingredient-base-border: var(--status-brand-border);
+  --ingredient-base-text: var(--status-brand-text);
+  --ingredient-spice-bg: var(--status-warning-bg);
+  --ingredient-spice-border: var(--status-warning-border);
+  --ingredient-spice-text: var(--status-warning-text);
+  --ingredient-sauce-bg: var(--status-info-bg);
+  --ingredient-sauce-border: var(--status-info-border);
+  --ingredient-sauce-text: var(--status-info-text);
+  --ingredient-packing-bg: rgba(98, 132, 147, 0.12);
+  --ingredient-packing-border: rgba(98, 132, 147, 0.26);
+  --ingredient-packing-text: rgba(210, 226, 233, 0.7);
+  --ingredient-electricity-bg: rgba(169, 121, 69, 0.12);
+  --ingredient-electricity-border: rgba(169, 121, 69, 0.26);
+  --ingredient-electricity-text: rgba(231, 207, 178, 0.7);
+  --ingredient-other-bg: rgba(148, 163, 184, 0.12);
+  --ingredient-other-border: rgba(148, 163, 184, 0.26);
+  --ingredient-other-text: rgba(218, 226, 236, 0.7);
+}
+
+[data-theme="dark"] .text-primary {
+  color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .text-secondary {
+  color: var(--text-secondary) !important;
+}
+
+[data-theme="dark"] .text-muted,
+[data-theme="dark"] .text-tertiary {
+  color: var(--text-tertiary) !important;
+}
+
+[data-theme="dark"] .text-success {
+  color: color-mix(in srgb, var(--good) 72%, var(--text-secondary)) !important;
+}
+
+[data-theme="dark"] .text-warning {
+  color: color-mix(in srgb, var(--warn) 68%, var(--text-secondary)) !important;
+}
+
+[data-theme="dark"] .text-danger,
+[data-theme="dark"] .text-error {
+  color: color-mix(in srgb, var(--danger) 72%, var(--text-secondary)) !important;
 }
 
 body {
@@ -694,14 +796,121 @@ h6,
   min-width: min(260px, 100%);
 }
 
+.unified-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.unified-filter-field {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.unified-filter-field.is-grow {
+  flex: 1 1 320px;
+  max-width: none;
+}
+
+.filter-bar .form-label,
+.filter-label {
+  min-height: 18px;
+  margin-bottom: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+}
+
+.filter-input-group,
+.filter-bar .input-group,
+.filter-bar .form-control,
+.filter-bar .react-select__control,
+.filter-chip-row,
+.filter-clear-button,
+.recipe-filter-summary {
+  min-height: var(--app-control-height-md);
+}
+
+.filter-bar .input-group-text,
+.filter-bar .form-control {
+  height: var(--app-control-height-md) !important;
+  min-height: var(--app-control-height-md);
+}
+
+.filter-bar .input-group-text,
+.filter-bar .form-control,
+.filter-bar .react-select__control {
+  border-color: var(--border-primary) !important;
+}
+
+.filter-bar .react-select__control {
+  min-height: var(--app-control-height-md) !important;
+  height: var(--app-control-height-md) !important;
+}
+
+.filter-bar .react-select__value-container {
+  height: calc(var(--app-control-height-md) - 2px) !important;
+  padding: 0 12px !important;
+}
+
+.filter-bar .input-group-text,
+.filter-bar .form-control {
+  padding: 0 12px !important;
+  line-height: calc(var(--app-control-height-md) - 2px) !important;
+}
+
+.filter-bar .filter-input-group .input-group-text {
+  padding: 0 var(--space-3) !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.filter-bar .filter-input-group .form-control {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.filter-bar .filter-input-group .input-group-text + .form-control {
+  margin-left: -1px;
+}
+
+.filter-bar input[type="date"]::-webkit-datetime-edit {
+  padding: 0;
+}
+
+.filter-bar input[type="date"]::-webkit-calendar-picker-indicator {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.filter-clear-button {
+  align-self: flex-end;
+}
+
+.filter-clear-button.is-hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+@media (min-width: 768px) {
+  .filter-clear-button.is-hidden {
+    display: none;
+  }
+}
+
 .filter-chip-row {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+  align-items: center;
 }
 
 .filter-chip {
-  min-height: var(--app-control-height-sm);
+  min-height: var(--app-control-height-md);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -739,11 +948,61 @@ h6,
   gap: var(--space-2);
 }
 
+.ingredient-type-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  letter-spacing: var(--tracking-wide);
+  white-space: nowrap;
+}
+
+.ingredient-type-badge.is-base {
+  background: var(--ingredient-base-bg);
+  border-color: var(--ingredient-base-border);
+  color: var(--ingredient-base-text);
+}
+
+.ingredient-type-badge.is-spice {
+  background: var(--ingredient-spice-bg);
+  border-color: var(--ingredient-spice-border);
+  color: var(--ingredient-spice-text);
+}
+
+.ingredient-type-badge.is-sauce {
+  background: var(--ingredient-sauce-bg);
+  border-color: var(--ingredient-sauce-border);
+  color: var(--ingredient-sauce-text);
+}
+
+.ingredient-type-badge.is-packing {
+  background: var(--ingredient-packing-bg);
+  border-color: var(--ingredient-packing-border);
+  color: var(--ingredient-packing-text);
+}
+
+.ingredient-type-badge.is-electricity {
+  background: var(--ingredient-electricity-bg);
+  border-color: var(--ingredient-electricity-border);
+  color: var(--ingredient-electricity-text);
+}
+
+.ingredient-type-badge.is-other {
+  background: var(--ingredient-other-bg);
+  border-color: var(--ingredient-other-border);
+  color: var(--ingredient-other-text);
+}
+
 .price-state-badge {
   display: inline-flex;
   align-items: center;
   min-height: 26px;
   padding: 0 var(--space-2);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   font-size: var(--text-xs);
   font-weight: var(--font-semibold);
@@ -751,13 +1010,38 @@ h6,
 }
 
 .price-state-badge.is-priced {
-  background: var(--good-bg);
-  color: var(--good);
+  background: var(--status-success-bg);
+  border-color: var(--status-success-border);
+  color: var(--status-success-text);
 }
 
 .price-state-badge.is-missing {
-  background: var(--warn-bg);
-  color: var(--warn);
+  background: var(--status-warning-bg);
+  border-color: var(--status-warning-border);
+  color: var(--status-warning-text);
+}
+
+.ingredients-filter-bar .filter-group {
+  max-width: none;
+  min-width: 0;
+}
+
+.ingredients-filter-bar .search-filter {
+  flex: 1 1 260px;
+  max-width: 360px;
+}
+
+.ingredients-filter-bar .ingredients-chip-filter {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.ingredients-filter-bar .filter-chip-row {
+  flex-wrap: nowrap;
+}
+
+.ingredients-filter-bar .filter-chip {
+  flex: 0 0 auto;
 }
 
 .client-card {
@@ -899,6 +1183,72 @@ h6,
   height: 7px;
 }
 
+[data-theme="dark"] .status-badge-info,
+.status-badge-info {
+  background: var(--status-info-bg);
+  border-color: var(--status-info-border);
+  color: var(--status-info-text);
+}
+
+[data-theme="dark"] .status-badge-brand,
+.status-badge-brand {
+  background: var(--status-brand-bg);
+  border-color: var(--status-brand-border);
+  color: var(--status-brand-text);
+}
+
+[data-theme="dark"] .status-badge-warning,
+.status-badge-warning {
+  background: var(--status-warning-bg);
+  border-color: var(--status-warning-border);
+  color: var(--status-warning-text);
+}
+
+[data-theme="dark"] .status-badge-success,
+.status-badge-success {
+  background: var(--status-success-bg);
+  border-color: var(--status-success-border);
+  color: var(--status-success-text);
+}
+
+[data-theme="dark"] .status-badge-error,
+.status-badge-error {
+  background: var(--status-error-bg);
+  border-color: var(--status-error-border);
+  color: var(--status-error-text);
+}
+
+[data-theme="dark"] .status-dot-brand,
+.status-dot-brand {
+  background: var(--chart-accent-brand);
+}
+
+[data-theme="dark"] .status-dot-success {
+  background: var(--chart-accent-good);
+}
+
+[data-theme="dark"] .status-dot-warning {
+  background: var(--chart-accent-warn);
+}
+
+[data-theme="dark"] .status-dot-error {
+  background: var(--chart-accent-danger);
+}
+
+[data-theme="dark"] .status-dot-info {
+  background: var(--chart-accent-info);
+}
+
+[data-theme="dark"] .badge.bg-primary,
+[data-theme="dark"] .badge.bg-info,
+[data-theme="dark"] .badge.bg-success,
+[data-theme="dark"] .badge.bg-warning,
+[data-theme="dark"] .badge.bg-danger {
+  background: var(--surface-tertiary) !important;
+  border: 1px solid var(--border-primary);
+  color: var(--text-secondary) !important;
+}
+
 .modal-content {
   box-shadow: var(--shadow-xl) !important;
 }
@@ -947,6 +1297,11 @@ h6,
 .modal-header,
 .modal-footer {
   background: var(--surface-primary) !important;
+}
+
+[data-theme="dark"] .modal-header,
+[data-theme="dark"] .modal-footer {
+  background: var(--surface-tertiary) !important;
 }
 
 .modal-title {
@@ -1303,6 +1658,19 @@ h6,
   border-radius: var(--radius-md);
 }
 
+@media (max-width: 1199.98px) {
+  .ingredients-filter-bar .filter-chip-row {
+    flex-wrap: wrap;
+  }
+
+  .filter-clear-button {
+    width: 100%;
+    justify-self: stretch;
+    justify-content: center;
+    margin-left: 0 !important;
+  }
+}
+
 @media (max-width: 767.98px) {
   .filter-bar {
     align-items: stretch;
@@ -1335,6 +1703,18 @@ h6,
     white-space: normal;
   }
 
+  .ingredients-filter-bar .ingredients-chip-filter {
+    min-width: 0;
+  }
+
+  .ingredients-filter-bar .filter-chip-row {
+    flex-wrap: wrap;
+  }
+
+  .filter-clear-button.is-hidden {
+    display: none;
+  }
+
   .mobile-sort-bar {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
@@ -1360,13 +1740,19 @@ h6,
   .ingredients-table-wrap,
   .prices-table-wrap {
     overflow-x: visible !important;
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
   }
 
   .workspace-ingredients-table,
   .prices-table {
     min-width: 0;
+    background: transparent !important;
+    border: 0 !important;
     border-collapse: separate;
-    border-spacing: 0 var(--space-3);
+    border-spacing: 0;
+    box-shadow: none !important;
   }
 
   .workspace-ingredients-table thead,
@@ -1375,17 +1761,23 @@ h6,
   }
 
   .workspace-ingredients-table tbody,
-  .workspace-ingredients-table tr,
   .workspace-ingredients-table td,
   .prices-table tbody,
-  .prices-table tr,
   .prices-table td {
     display: block;
     width: 100%;
   }
 
-  .workspace-ingredients-table tr,
-  .prices-table tr {
+  .workspace-ingredients-table tbody,
+  .prices-table tbody {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .workspace-ingredients-table tbody tr,
+  .prices-table tbody tr {
+    display: block;
+    width: 100%;
     padding: var(--space-3);
     border: 1px solid var(--border-primary);
     border-radius: var(--radius-lg);
@@ -1396,13 +1788,11 @@ h6,
   .workspace-ingredients-table td,
   .prices-table td {
     max-width: none;
-    min-height: 34px;
-    display: grid;
-    grid-template-columns: minmax(96px, 0.42fr) minmax(0, 1fr);
-    gap: var(--space-3);
-    align-items: start;
+    min-height: 0;
+    display: block;
     padding: var(--space-2) 0 !important;
     border: 0 !important;
+    background: transparent !important;
     white-space: normal;
   }
 
@@ -1416,9 +1806,12 @@ h6,
   .workspace-ingredients-table td::before,
   .prices-table td::before {
     content: attr(data-label);
+    display: block;
+    margin-bottom: var(--space-1);
     color: var(--text-tertiary);
     font-size: var(--text-xs);
     font-weight: var(--font-bold);
+    line-height: var(--leading-tight);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
   }
@@ -1426,7 +1819,6 @@ h6,
   .workspace-ingredients-table td:first-child,
   .prices-table td:nth-child(2),
   .prices-table td:nth-child(3) {
-    align-items: center;
     color: var(--text-primary);
     font-size: var(--text-base);
   }
@@ -1763,6 +2155,7 @@ h6,
   max-width: none;
 }
 
+.recipe-filter-strip .filter-label,
 .recipe-filter-strip .form-label,
 .recipe-detail-table-head {
   margin-bottom: var(--space-2);
@@ -1773,14 +2166,15 @@ h6,
   text-transform: uppercase;
 }
 
+.recipe-filter-strip .filter-label,
 .recipe-filter-strip .form-label {
   min-height: 18px;
 }
 
 .recipe-filter-strip .form-control,
 .recipe-filter-strip .react-select__control {
-  height: 44px;
-  min-height: 44px;
+  height: var(--app-control-height-md);
+  min-height: var(--app-control-height-md);
   border: 1px solid var(--border-primary) !important;
   border-radius: var(--radius-md) !important;
   border-color: var(--border-primary);
@@ -1789,13 +2183,13 @@ h6,
 }
 
 .recipe-filter-strip .form-control {
-  padding: 10px 12px;
-  line-height: 22px;
+  padding: 0 12px;
+  line-height: var(--app-control-height-md);
 }
 
 .recipe-filter-strip .react-select__value-container {
   min-width: 0;
-  height: 42px;
+  height: calc(var(--app-control-height-md) - 2px);
   flex-wrap: nowrap !important;
   overflow: hidden;
   padding: 2px 12px !important;
@@ -1824,7 +2218,7 @@ h6,
 }
 
 .recipe-filter-summary {
-  min-height: 44px;
+  min-height: var(--app-control-height-md);
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -148,6 +148,58 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
   min-width: 0 !important;
 }
 
+/* === EMPTY STATES === */
+.empty-state {
+  width: 100%;
+  padding: var(--space-10) var(--space-6);
+  border: 1px dashed var(--border-secondary);
+  border-radius: var(--radius-lg);
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  text-align: center;
+}
+
+.empty-state-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.empty-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--space-4);
+  color: var(--text-tertiary);
+}
+
+.empty-state-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-tight);
+}
+
+.empty-state-action {
+  margin-top: var(--space-4);
+}
+
+[data-theme="dark"] .empty-state {
+  background: var(--surface-primary);
+  border-color: var(--border-primary);
+}
+
+[data-theme="dark"] .empty-state-icon {
+  color: var(--text-tertiary);
+}
+
+[data-theme="dark"] .empty-state-title {
+  color: var(--text-secondary);
+}
+
 /* === RECIPE CARDS === */
 .recipe-card {
   height: 100%;
@@ -352,6 +404,37 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 
 .client-contact-link:hover {
   color: var(--brand-500);
+}
+
+.client-source {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-primary);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+.source-label {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+}
+
+.source-value {
+  min-width: 0;
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .client-source {
+  border-color: var(--border-primary);
+  color: var(--text-secondary);
 }
 
 /* === RECIPES GRID === */
@@ -978,6 +1061,11 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
   opacity: 1;
 }
 
+[data-theme="dark"] .btn-close {
+  filter: invert(1) grayscale(100%);
+  opacity: 0.72;
+}
+
 /* Modal forms */
 .modal-form {
   display: flex;
@@ -1030,6 +1118,119 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 [data-theme="dark"] .modal-footer {
   background: var(--surface-tertiary) !important;
   border-color: var(--border-primary) !important;
+}
+
+.modal-token-panel {
+  background: var(--surface-secondary) !important;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+}
+
+.modal-token-option {
+  width: 100%;
+  border: 1px solid var(--border-primary) !important;
+  background: var(--surface-primary) !important;
+  color: var(--text-primary) !important;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.modal-token-option:hover:not(:disabled) {
+  border-color: var(--border-secondary) !important;
+  background: var(--surface-secondary) !important;
+}
+
+.modal-section-title {
+  color: var(--text-secondary) !important;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+}
+
+.modal-empty-state {
+  background: var(--surface-secondary) !important;
+  border: 1px dashed var(--border-secondary);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+}
+
+.modal-selected-value {
+  color: var(--text-primary) !important;
+}
+
+.client-modal-field-icon {
+  color: var(--text-secondary);
+}
+
+.client-modal-required-note {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.client-modal-required-mark {
+  color: var(--danger);
+  font-weight: var(--font-bold);
+}
+
+[data-theme="dark"] .modal-token-panel,
+[data-theme="dark"] .modal-empty-state {
+  background: var(--surface-tertiary) !important;
+  border-color: var(--border-primary);
+}
+
+[data-theme="dark"] .modal-token-option {
+  background: var(--surface-secondary) !important;
+  border-color: var(--border-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .modal-token-option:hover:not(:disabled) {
+  background: var(--surface-tertiary) !important;
+  border-color: var(--border-secondary) !important;
+}
+
+[data-theme="dark"] .modal-body .list-group-item {
+  background: var(--surface-secondary);
+  border-color: var(--border-primary);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .client-modal-field-icon {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .client-modal-required-note {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .client-modal .mapboxgl-ctrl-geocoder {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-primary);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .client-modal .mapboxgl-ctrl-geocoder input {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .client-modal .mapboxgl-ctrl-geocoder input::placeholder {
+  color: var(--text-tertiary);
+}
+
+[data-theme="dark"] .client-modal .suggestions {
+  background: var(--surface-primary);
+  border: 1px solid var(--border-primary);
+}
+
+[data-theme="dark"] .client-modal .suggestions > li > a {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .client-modal .suggestions > .active > a,
+[data-theme="dark"] .client-modal .suggestions > li > a:hover {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .modal-body .alert-danger {
@@ -1537,41 +1738,35 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 }
 
 .profile-card-header {
-  padding: 20px 24px;
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--border-primary);
-}
-
-.profile-card-header.bg-primary {
-  background: var(--brand-500) !important;
-}
-
-.profile-card-header.bg-warning {
-  background: var(--warning-100) !important;
+  background: var(--surface-secondary);
 }
 
 .profile-card-title {
-  font-size: var(--text-lg);
-  font-weight: var(--font-bold);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   margin: 0;
   display: flex;
   align-items: center;
 }
 
-.profile-card-header.bg-primary .profile-card-title {
-  color: var(--text-inverse);
-}
-
-.profile-card-header.bg-warning .profile-card-title {
-  color: var(--warning-700);
+.profile-card-title svg {
+  color: var(--text-secondary);
 }
 
 .profile-card-body {
-  padding: 24px;
+  padding: var(--space-5);
   flex: 1;
 }
 
 .profile-info-item {
-  padding: 12px 0;
+  display: grid;
+  grid-template-columns: minmax(120px, 0.42fr) minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) 0;
   border-bottom: 1px solid var(--border-primary);
 }
 
@@ -1580,30 +1775,32 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 }
 
 .profile-info-item .info-label {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-  margin-bottom: 4px;
   display: flex;
   align-items: center;
-  font-weight: var(--font-medium);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  letter-spacing: var(--tracking-caps);
+  line-height: var(--leading-tight);
+  text-transform: uppercase;
 }
 
 .profile-info-item .info-value {
-  font-size: var(--text-base);
   color: var(--text-primary);
   font-weight: var(--font-semibold);
+  min-width: 0;
 }
 
 .profile-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--space-4);
 }
 
 .form-row {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 20px;
+  gap: var(--space-4);
 }
 
 @media (min-width: 768px) {
@@ -1613,8 +1810,84 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 }
 
 .submit-button {
-  margin-top: 8px;
+  margin-top: var(--space-1);
   width: 100%;
+}
+
+.profile-password-group .input-group-text,
+.profile-password-group .form-control,
+.profile-password-group .profile-password-toggle {
+  height: var(--app-control-height-md) !important;
+  min-height: var(--app-control-height-md);
+  border-color: var(--border-primary) !important;
+}
+
+.profile-password-group .input-group-text {
+  min-width: 40px;
+  justify-content: center;
+  background: var(--surface-secondary) !important;
+  color: var(--text-secondary) !important;
+  padding: 0 var(--space-3) !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.profile-password-group .form-control {
+  background: var(--surface-primary);
+  color: var(--text-primary);
+  border-radius: 0 !important;
+  margin-left: -1px;
+  padding-left: var(--space-3) !important;
+  padding-right: var(--space-3) !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  line-height: calc(var(--app-control-height-md) - 2px) !important;
+}
+
+.profile-password-group .profile-password-toggle {
+  width: 40px;
+  min-width: 40px;
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  border-top-right-radius: var(--radius-md) !important;
+  border-bottom-right-radius: var(--radius-md) !important;
+  padding: 0 !important;
+  margin-left: -1px;
+  justify-content: center;
+  border-top: 1px solid var(--border-primary) !important;
+  border-right: 1px solid var(--border-primary) !important;
+  border-bottom: 1px solid var(--border-primary) !important;
+  border-left: 0 !important;
+  background: var(--surface-primary) !important;
+  color: var(--text-secondary) !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+.profile-password-group .profile-password-toggle svg {
+  width: 15px;
+  height: 15px;
+  display: block;
+}
+
+.profile-password-group .profile-password-toggle:hover {
+  background: var(--surface-tertiary) !important;
+  color: var(--text-primary) !important;
+  border-top-color: var(--border-secondary) !important;
+  border-right-color: var(--border-secondary) !important;
+  border-bottom-color: var(--border-secondary) !important;
+}
+
+.profile-password-group .profile-password-toggle:focus,
+.profile-password-group .profile-password-toggle:focus-visible {
+  background: var(--surface-tertiary) !important;
+  color: var(--text-primary) !important;
+  box-shadow: 0 0 0 3px var(--batchvault-burgundy-soft) !important;
+  outline: none;
+}
+
+.profile-form .form-label {
+  color: var(--text-secondary);
 }
 
 /* Dark mode for profile */
@@ -1627,12 +1900,15 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
   border-color: var(--border-primary);
 }
 
-[data-theme="dark"] .profile-card-header.bg-warning {
-  background: rgba(245, 158, 11, 0.2) !important;
+[data-theme="dark"] .profile-card-header {
+  background: var(--surface-secondary);
 }
 
-[data-theme="dark"] .profile-card-header.bg-warning .profile-card-title {
-  color: #fbbf24 !important;
+@media (max-width: 575.98px) {
+  .profile-info-item {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
 }
 
 /* === ORDER ITEMS IN MODAL === */
@@ -1708,11 +1984,13 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 .summary-label {
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
+  color: var(--text-secondary);
 }
 
 .summary-value {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
+  color: var(--text-primary);
 }
 
 /* Dark mode for order items */
@@ -1729,6 +2007,18 @@ div.products-sections > div.recipe-section > div.products-grid > div.product-gri
 [data-theme="dark"] .order-summary {
   background: var(--surface-tertiary);
   border-color: var(--border-primary);
+}
+
+[data-theme="dark"] .order-summary .summary-label {
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .order-summary .summary-value {
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .order-summary .text-secondary {
+  color: var(--text-secondary) !important;
 }
 
 /* === FORM SECTIONS === */

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -304,6 +304,48 @@ p {
   letter-spacing: 0.05em;
 }
 
+.input-group-text {
+  background: var(--surface-secondary) !important;
+  border-color: var(--border-primary) !important;
+  color: var(--text-secondary) !important;
+}
+
+.input-group .form-control {
+  border-color: var(--border-primary);
+}
+
+.input-group .form-control:focus {
+  position: relative;
+  z-index: 3;
+}
+
+[data-theme="dark"] .input-group-text {
+  background: var(--surface-tertiary) !important;
+  border-color: var(--border-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+[data-theme="dark"] .filter-bar .input-group-text,
+[data-theme="dark"] .modal-body .input-group-text {
+  background: var(--surface-secondary) !important;
+  border-color: var(--border-primary) !important;
+  color: var(--text-secondary) !important;
+}
+
+[data-theme="dark"] .filter-bar .form-control,
+[data-theme="dark"] .modal-body .form-control,
+[data-theme="dark"] .modal-body .form-select {
+  background: var(--surface-primary);
+  border-color: var(--border-primary);
+  color: var(--text-primary);
+}
+
+[data-theme="dark"] .filter-bar .form-control::placeholder,
+[data-theme="dark"] .modal-body .form-control::placeholder {
+  color: var(--text-tertiary);
+  opacity: 1;
+}
+
 /* === TABLES === */
 .table {
   width: 100% !important;

--- a/src/utils/ingredientTypes.ts
+++ b/src/utils/ingredientTypes.ts
@@ -1,0 +1,63 @@
+import { IconType } from 'react-icons';
+import { FaBolt, FaBoxOpen, FaFlask, FaList, FaTag, FaTint, FaUtensils } from 'react-icons/fa';
+
+export type IngredientTypeValue = 'base' | 'spice' | 'sauce' | 'packing' | 'electricity';
+
+type IngredientTypeMeta = {
+  value: IngredientTypeValue;
+  labelKey: string;
+  icon: IconType;
+  badgeClass: string;
+  units: string[];
+};
+
+export type IngredientTypeOption = {
+  value: string;
+  label: string;
+  icon: IconType;
+};
+
+const INGREDIENT_TYPES: IngredientTypeMeta[] = [
+  { value: 'base', labelKey: 'base', icon: FaUtensils, badgeClass: 'is-base', units: ['kg', 'g'] },
+  { value: 'spice', labelKey: 'spice', icon: FaFlask, badgeClass: 'is-spice', units: ['g'] },
+  { value: 'sauce', labelKey: 'sauce', icon: FaTint, badgeClass: 'is-sauce', units: ['ml'] },
+  { value: 'packing', labelKey: 'packing', icon: FaBoxOpen, badgeClass: 'is-packing', units: ['pieces'] },
+  { value: 'electricity', labelKey: 'electricity', icon: FaBolt, badgeClass: 'is-electricity', units: ['hh'] },
+];
+
+const FALLBACK_TYPE = {
+  labelKey: 'ingredientType',
+  icon: FaTag,
+  badgeClass: 'is-other',
+  units: [],
+};
+
+export const getIngredientTypes = () => INGREDIENT_TYPES;
+
+export const getIngredientTypeMeta = (type?: string) => (
+  INGREDIENT_TYPES.find((option) => option.value === type) || FALLBACK_TYPE
+);
+
+export const getIngredientTypeOptions = (
+  t: (key: string) => string,
+  options: { includeAll?: boolean } = {}
+): IngredientTypeOption[] => {
+  const typeOptions = INGREDIENT_TYPES.map((type) => ({
+    value: type.value,
+    label: t(type.labelKey),
+    icon: type.icon,
+  }));
+
+  if (!options.includeAll) {
+    return typeOptions;
+  }
+
+  return [
+    { value: 'all', label: t('allTypes'), icon: FaList },
+    ...typeOptions,
+  ];
+};
+
+export const getIngredientTypeBadgeClass = (type?: string) => getIngredientTypeMeta(type).badgeClass;
+
+export const getUnitsForIngredientType = (type?: string) => getIngredientTypeMeta(type).units;


### PR DESCRIPTION
## Summary

- tokenized dark-theme modal, form, empty-state, and profile controls
- introduced shared filter primitives and centralized ingredient type metadata/badges
- normalized dashboard, status pill, chart, mobile card, and list-filter styling across the app

## Why

The dark theme had inconsistent Bootstrap defaults leaking through modals, filter bars, empty states, status badges, and profile controls. Some pages also duplicated ingredient type display logic and used page-local filter layouts that drifted visually.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`
- Browser smoke checks on dashboard, profile, clients, ingredients, orders, prices, products, recipes, and affected modals in dark theme

## Notes

- Non-mutating browser QA was used for authenticated flows.
- Local untracked screenshots and Codex working files are intentionally not included in this PR.
